### PR TITLE
Hubbard correction treated by sirius.

### DIFF
--- a/PW/src/force_hub.f90
+++ b/PW/src/force_hub.f90
@@ -58,8 +58,8 @@ SUBROUTINE force_hub(forceh)
 
    call start_clock('force_hub')
 
-!  if (use_sirius) then
-!      call sirius_get_forces(c_str("hubbard"), forceh(1, 1))
+   ! if (use_sirius) then
+!   call sirius_get_forces(c_str("hubbard"), forceh(1, 1))
 !      forceh = forceh * 2.0 ! convert to Ry
      !call symvector(nat, forceh)
      !call stop_clock('force_hub')

--- a/PW/src/force_hub.f90
+++ b/PW/src/force_hub.f90
@@ -38,6 +38,7 @@ SUBROUTINE force_hub(forceh)
    USE wavefunctions_module, ONLY : evc
    USE klist,                ONLY : nks, xk, ngk, igk_k
    USE io_files,             ONLY : nwordwfc, iunwfc
+   USE mod_sirius
    USE buffers,              ONLY : get_buffer
 
    IMPLICIT NONE

--- a/PW/src/forces.f90
+++ b/PW/src/forces.f90
@@ -137,8 +137,6 @@ SUBROUTINE forces()
     call sirius_set_pw_coeffs(c_str("dveff"), vxc_g(1), ngm, mill(1, 1), intra_bgrp_comm)
 
     deallocate(vxc_g)
-  
-    call sirius_calculate_forces(kset_id)
   endif
   CALL start_clock( 'forces' )
   !

--- a/PW/src/mod_sirius.f90
+++ b/PW/src/mod_sirius.f90
@@ -144,6 +144,8 @@ use lsda_mod, only : lsda, nspin, starting_magnetization
 use cell_base, only : omega
 use symm_base, only : nosym
 use spin_orb,  only : lspinorb
+use ldaU, only : lda_plus_U, Hubbard_J, Hubbard_U, Hubbard_alpha, &
+     & Hubbard_beta, is_Hubbard, lda_plus_u_kind, Hubbard_J0, U_projection, Hubbard_l
 use esm,       only : esm_local, esm_bc, do_comp_esm
 use mp_diag, only : nproc_ortho
 implicit none
@@ -155,7 +157,8 @@ real(8), allocatable :: dion(:, :), qij(:,:,:), vloc(:), wk_tmp(:), xk_tmp(:,:)
 integer, allocatable :: nk_loc(:)
 integer :: ih, jh, ijh, lmax_beta
 logical(C_BOOL) bool_var
-
+INTEGER,EXTERNAL           :: set_hubbard_l,set_hubbard_n
+real(8), external :: hubbard_occ
 !if (allocated(atom_type)) then
 !  do iat = 1, nsp
 !    if (allocated(atom_type(iat)%qpw)) deallocate(atom_type(iat)%qpw)
@@ -187,7 +190,7 @@ if (i * i .ne. num_ranks_k) then
   !stop ("not a square MPI grid")
   dims(1) = 1
   dims(2) = num_ranks_k
-else 
+else
   dims(1) = i
   dims(2) = i
 endif
@@ -219,6 +222,21 @@ else
       endif
    endif
 endif
+
+if (lda_plus_U) then
+   call sirius_set_hubbard_correction()
+   if (lda_plus_u_kind == 0) then
+      call sirius_set_hubbard_simplified_method()
+   endif
+   if (U_projection == "ortho-atomic") then
+      call sirius_set_orthogonalize_hubbard_orbitals()
+   endif
+
+   if (U_projection == "norm-atomic") then
+      call sirius_set_normalize_hubbard_orbitals()
+   endif
+endif
+
 
 if (diago_full_acc) then
   call sirius_set_empty_states_tolerance(0.d0)
@@ -264,15 +282,32 @@ do iat = 1, nsp
 
   ! set beta-projectors
   do i = 1, upf(iat)%nbeta
-    call sirius_add_atom_type_beta_radial_function(atom_type(iat)%label, upf(iat)%lll(i),&
-                                                  &upf(iat)%beta(1, i), upf(iat)%kbeta(i))
+     l = upf(iat)%lll(i);
+     if (upf(iat)%has_so) then
+        if (upf(iat)%jjj(i) .le. upf(iat)%lll(i)) then
+           l = - upf(iat)%lll(i)
+        endif
+     endif
+     call sirius_add_atom_type_beta_radial_function(atom_type(iat)%label, l,&
+          &upf(iat)%beta(1, i), upf(iat)%kbeta(i))
   enddo
 
   ! set the atomic radial functions
   do iwf = 1, upf(iat)%nwfc
-    l = upf(iat)%lchi(iwf)
-    call sirius_add_atom_type_ps_atomic_wf(atom_type(iat)%label, l, upf(iat)%chi(1, iwf), 0.d0, msh(iat))
+     l = upf(iat)%lchi(iwf)
+     if (upf(iat)%has_so) then
+        if (upf(iat)%jchi(iwf) < l) then
+           l = -l
+        endif
+     endif
+     call sirius_add_atom_type_ps_atomic_wf(atom_type(iat)%label, l, upf(iat)%chi(1, iwf), upf(iat)%oc(iwf), msh(iat))
   enddo
+  if (is_hubbard(iat)) then
+     call sirius_set_atom_type_hubbard(atom_type(iat)%label, Hubbard_l(iat), &
+          set_hubbard_n(upf(iat)%psd), hubbard_occ ( upf(iat)%psd ), &
+          Hubbard_U(iat), Hubbard_J(1,iat), &
+          Hubbard_alpha(iat), Hubbard_beta(iat), Hubbard_J0(iat))
+  endif
 
   allocate(dion(upf(iat)%nbeta, upf(iat)%nbeta))
   ! convert to hartree
@@ -305,7 +340,7 @@ do iat = 1, nsp
          &upf(iat)%paw%core_energy, upf(iat)%paw%ae_rho_atc(1),&
          &upf(iat)%mesh, upf(iat)%paw%oc(1), upf(iat)%nbeta )
   endif
-  
+
   ! TODO: pass PW coefficients of this functions
 
   ! set non-linear core correction
@@ -323,7 +358,7 @@ do iat = 1, nsp
 
   ! set total charge density of a free atom (to compute initial rho(r))
   call sirius_set_atom_type_rho_tot(atom_type(iat)%label, upf(iat)%mesh, upf(iat)%rho_at(1))
-  
+
   ! the hack is done in Modules/readpp.f90
   if (use_sirius_vloc) then
     allocate(vloc(upf(iat)%mesh))
@@ -343,7 +378,7 @@ do iat = 1, nsp
   !call test_integration(msh(iat), upf(iat)%r, upf(iat)%rab)
   !call test_integration(upf(iat)%mesh, upf(iat)%r, upf(iat)%rab)
 enddo
-  
+
 ! add atoms to the unit cell
 ! WARNING: sirius accepts only fractional coordinates;
 !          if QE stores coordinates in a different way, the conversion must be made here
@@ -378,8 +413,6 @@ call sirius_set_esm(bool_var, esm_bc)
 ! initialize global variables/indices/arrays/etc. of the simulation
 call sirius_initialize_simulation_context()
 
-call sirius_create_potential
-  
 !! get number of g-vectors of the dense fft grid
 !call sirius_get_num_gvec(num_gvec)
 !
@@ -446,10 +479,10 @@ call sirius_create_kset(num_kpoints, kpoints(1, 1), wkpoints(1), 1, kset_id)
 !deallocate(xk_tmp)
 
 ! create Density class
-call sirius_create_density()
- 
+! call sirius_create_density()
+
 ! create Potential class
-call sirius_create_potential()
+! call sirius_create_potential()
 
 ! create ground-state class
 call sirius_create_ground_state(kset_id)
@@ -858,7 +891,7 @@ subroutine get_band_energies_from_sirius
   integer :: ik, nk, nb, nfv
 
   allocate(band_e(nbnd, nkstot))
-  
+
   ! get band energies
   if (nspin.ne.2) then
     ! non-magnetic or non-collinear case
@@ -873,14 +906,14 @@ subroutine get_band_energies_from_sirius
       call sirius_get_band_energies(kset_id, ik, 0, band_e(1, ik))
       call sirius_get_band_energies(kset_id, ik, 1, band_e(1, nk + ik))
     end do
-  
+
   endif
-  
+
   ! convert to Ry
   do ik = 1, nks
     et(:, ik) = 2.d0 * band_e(:, global_kpoint_index(nkstot, ik))
   enddo
-  
+
   deallocate(band_e)
 
 end subroutine get_band_energies_from_sirius
@@ -902,7 +935,7 @@ subroutine put_band_occupancies_to_sirius
   real(8), allocatable :: bnd_occ(:, :)
   real(8) :: maxocc
   integer :: ik, ierr, nk, nb
-  
+
   ! compute occupancies
   allocate(bnd_occ(nbnd, nkstot))
   bnd_occ = 0.d0
@@ -915,20 +948,20 @@ subroutine put_band_occupancies_to_sirius
     bnd_occ(:, global_kpoint_index(nkstot, ik)) = maxocc * wg(:, ik) / wk(ik)
   enddo
   call mpi_allreduce(MPI_IN_PLACE, bnd_occ(1, 1), nbnd * nkstot, MPI_DOUBLE, MPI_SUM, inter_pool_comm, ierr)
-  
+
   if (nspin.ne.2) then
     ! set band occupancies
     do ik = 1, nkstot
       call sirius_set_band_occupancies(kset_id, ik, 0, bnd_occ(1, ik))
     enddo
-  else 
+  else
     nk = nkstot / 2
     do ik = 1, nk
       call sirius_set_band_occupancies(kset_id, ik, 0, bnd_occ(1, ik))
       call sirius_set_band_occupancies(kset_id, ik, 1, bnd_occ(1, ik + nk))
     enddo
   endif
-  
+
   deallocate(bnd_occ)
 
 end subroutine put_band_occupancies_to_sirius
@@ -952,7 +985,7 @@ subroutine get_density_matrix_from_sirius
       if (ityp(na).eq.iat.and.allocated(rho%bec)) then
         rho%bec(:, na, :) = 0.d0
         call sirius_get_density_matrix(na, dens_mtrx(1, 1, 1), nhm)
-  
+
         ijh = 0
         do ih = 1, nh(iat)
           do jh = ih, nh(iat)
@@ -997,10 +1030,10 @@ subroutine get_density_from_sirius
   !
   integer iat, ig, ih, jh, ijh, na, ispn
   complex(8) z1, z2
-  
+
   ! get rho(G)
   call sirius_get_pw_coeffs(c_str("rho"), rho%of_g(1, 1), ngm, mill(1, 1), intra_bgrp_comm)
-  
+
   if (nspin.eq.2) then
     call sirius_get_pw_coeffs(c_str("magz"), rho%of_g(1, 2), ngm, mill(1, 1), intra_bgrp_comm)
     ! convert to rho_{up}, rho_{dn}
@@ -1230,7 +1263,7 @@ subroutine put_potential_to_sirius
     enddo
 
     do ig = 1, ngm
-      z1 = v%of_g(ig, 1) 
+      z1 = v%of_g(ig, 1)
       z2 = v%of_g(ig, 2)
       v%of_g(ig, 1) = 0.5 * (z1 + z2)
       v%of_g(ig, 2) = 0.5 * (z1 - z2)
@@ -1370,12 +1403,12 @@ do ik = 1, nksmax
     if (lsda.and.ispn.eq.2) then
       ik_ = ik_ - nkstot / 2
     endif
-    call sirius_get_wave_functions(kset_id, ik_, ispn, ngk(ik), gvl(1, 1), evc(1, 1), npwx, npol) 
+    call sirius_get_wave_functions(kset_id, ik_, ispn, ngk(ik), gvl(1, 1), evc(1, 1), npwx, npol)
     if (nks > 1 .or. lelfield) then
       call save_buffer ( evc, nwordwfc, iunwfc, ik )
     endif
   else
-     call sirius_get_wave_functions(kset_id, -1, -1, -1, -1, z1, -1, -1) 
+     call sirius_get_wave_functions(kset_id, -1, -1, -1, -1, z1, -1, -1)
   endif
 enddo
 deallocate(gvl)
@@ -1424,7 +1457,7 @@ end subroutine get_wave_functions_from_sirius
 !  use sirius
 !  !
 !  implicit none
-!  
+!
 !  etxcc = 0.0d0
 !  if (any(upf(1:ntyp)%nlcc)) then
 !    call sirius_get_pw_coeffs(c_str("rhoc"), rhog_core(1), ngm, mill(1, 1), intra_bgrp_comm)
@@ -1433,7 +1466,7 @@ end subroutine get_wave_functions_from_sirius
 !    if (gamma_only) psic(dfftp%nlm(:)) = conjg(rhog_core(:))
 !    call invfft ('Rho', psic, dfftp)
 !    rho_core(:) = psic(:)
-!  else 
+!  else
 !    rhog_core(:) = 0.0d0
 !    rho_core(:)  = 0.0d0
 !  endif

--- a/PW/src/new_ns.f90
+++ b/PW/src/new_ns.f90
@@ -15,10 +15,10 @@ SUBROUTINE new_ns(ns)
   ! These quantities are defined as follows: ns_{I,s,m1,m2} = \sum_{k,v}
   ! f_{kv} <\fi^{at}_{I,m1}|\psi_{k,v,s}><\psi_{k,v,s}|\fi^{at}_{I,m2}>
 
-  !  It seems that the order of {m1, m2} in the definition should be opposite. 
+  !  It seems that the order of {m1, m2} in the definition should be opposite.
   !  Hovewer, since ns is symmetric (and real for collinear case, due to time
-  !  reversal) it does not matter.  
-  !  (A.Smogunov) 
+  !  reversal) it does not matter.
+  !  (A.Smogunov)
 
 
   !
@@ -40,7 +40,7 @@ SUBROUTINE new_ns(ns)
   USE mp,                   ONLY : mp_sum
   USE becmod,               ONLY : bec_type, calbec, &
                                    allocate_bec_type, deallocate_bec_type
-
+  USE mod_sirius
   IMPLICIT NONE
   !
   REAL(DP), INTENT(OUT) :: ns(2*Hubbard_lmax+1,2*Hubbard_lmax+1,nspin,nat)
@@ -55,8 +55,8 @@ SUBROUTINE new_ns(ns)
 
   CALL start_clock('new_ns')
   ldim = 2 * Hubbard_lmax + 1
-  ALLOCATE( nr(ldim,ldim,nspin,nat) )  
-  CALL allocate_bec_type ( nwfcU, nbnd, proj ) 
+  ALLOCATE( nr(ldim,ldim,nspin,nat) )
+  CALL allocate_bec_type ( nwfcU, nbnd, proj )
   !
   ! D_Sl for l=1, l=2 and l=3 are already initialized, for l=0 D_S0 is 1
   !
@@ -64,85 +64,92 @@ SUBROUTINE new_ns(ns)
   !
   nr (:,:,:,:) = 0.d0
   ns (:,:,:,:) = 0.d0
-  !
-  !    we start a loop on k points
-  !
-  DO ik = 1, nks
-     IF (lsda) current_spin = isk(ik)
-     npw = ngk (ik)
-     IF (nks > 1) &
-        CALL get_buffer  (evc, nwordwfc, iunwfc, ik)
-     !
-     ! make the projection
-     !
-     IF ( U_projection == 'pseudo' ) THEN
-        !
-        CALL compute_pproj( q_ae, proj )
-        ! does not need mp_sum intra-pool, since it is already done in calbec
-        !
-     ELSE
-        IF (nks > 1) CALL get_buffer (wfcU, nwordwfcU, iunhub, ik)
-        CALL calbec ( npw, wfcU, evc, proj )
-     END IF
-     !
-     ! compute the occupation numbers (the quantities n(m1,m2)) of the
-     ! atomic orbitals
-     !
-     DO na = 1, nat  
-        nt = ityp (na)  
-        IF ( is_hubbard(nt) ) THEN  
-           DO m1 = 1, 2 * Hubbard_l(nt) + 1  
-              DO m2 = m1, 2 * Hubbard_l(nt) + 1
-                 IF ( gamma_only ) THEN
-                    DO ibnd = 1, nbnd  
-                       nr(m1,m2,current_spin,na) = nr(m1,m2,current_spin,na) + &
-                            proj%r(offsetU(na)+m2,ibnd) * &
-                            proj%r(offsetU(na)+m1,ibnd) * wg(ibnd,ik) 
-                    ENDDO
-                 ELSE
-                    DO ibnd = 1, nbnd  
-                       nr(m1,m2,current_spin,na) = nr(m1,m2,current_spin,na) + &
-                            DBLE( proj%k(offsetU(na)+m2,ibnd) * &
-                            CONJG(proj%k(offsetU(na)+m1,ibnd)) ) * wg(ibnd,ik) 
-                    ENDDO
-                 END IF
-              ENDDO
-           ENDDO
-        ENDIF
-    ENDDO
-! on k-points
 
-  ENDDO
-  CALL deallocate_bec_type (proj) 
-  !
-  CALL mp_sum( nr, inter_pool_comm )
-  !
-  IF (nspin.EQ.1) nr = 0.5d0 * nr
-  !
-  ! impose hermiticity of n_{m1,m2}
-  !
-  DO na = 1, nat  
-     nt = ityp(na)
-     DO is = 1, nspin  
-        DO m1 = 1, 2 * Hubbard_l(nt) + 1
-           DO m2 = m1 + 1, 2 * Hubbard_l(nt) + 1  
-              nr (m2, m1, is, na) = nr (m1, m2, is, na)  
+  if (use_sirius) then
+     call sirius_calculate_hubbard_occupancies()
+     call sirius_get_hubbard_occupancies(nr(1,1,1,1), ldim)
+  else
+     !
+     !    we start a loop on k points
+     !
+     DO ik = 1, nks
+        IF (lsda) current_spin = isk(ik)
+        npw = ngk (ik)
+        IF (nks > 1) &
+             CALL get_buffer  (evc, nwordwfc, iunwfc, ik)
+        !
+        ! make the projection
+        !
+        IF ( U_projection == 'pseudo' ) THEN
+           !
+           CALL compute_pproj( q_ae, proj )
+           ! does not need mp_sum intra-pool, since it is already done in calbec
+           !
+        ELSE
+           IF (nks > 1) CALL get_buffer (wfcU, nwordwfcU, iunhub, ik)
+           CALL calbec ( npw, wfcU, evc, proj )
+        END IF
+        !
+        ! compute the occupation numbers (the quantities n(m1,m2)) of the
+        ! atomic orbitals
+        !
+        DO na = 1, nat
+           nt = ityp (na)
+           IF ( is_hubbard(nt) ) THEN
+              DO m1 = 1, 2 * Hubbard_l(nt) + 1
+                 DO m2 = m1, 2 * Hubbard_l(nt) + 1
+                    IF ( gamma_only ) THEN
+                       DO ibnd = 1, nbnd
+                          nr(m1,m2,current_spin,na) = nr(m1,m2,current_spin,na) + &
+                               proj%r(offsetU(na)+m2,ibnd) * &
+                               proj%r(offsetU(na)+m1,ibnd) * wg(ibnd,ik)
+                       ENDDO
+                    ELSE
+                       DO ibnd = 1, nbnd
+                          nr(m1,m2,current_spin,na) = nr(m1,m2,current_spin,na) + &
+                               DBLE( proj%k(offsetU(na)+m2,ibnd) * &
+                               CONJG(proj%k(offsetU(na)+m1,ibnd)) ) * wg(ibnd,ik)
+                       ENDDO
+                    END IF
+                 ENDDO
+              ENDDO
+           ENDIF
+        ENDDO
+        ! on k-points
+
+     ENDDO
+
+     CALL deallocate_bec_type (proj)
+     !
+     CALL mp_sum( nr, inter_pool_comm )
+     !
+     IF (nspin.EQ.1) nr = 0.5d0 * nr
+     !
+     ! impose hermiticity of n_{m1,m2}
+     !
+     DO na = 1, nat
+        nt = ityp(na)
+        DO is = 1, nspin
+           DO m1 = 1, 2 * Hubbard_l(nt) + 1
+              DO m2 = m1 + 1, 2 * Hubbard_l(nt) + 1
+                 nr (m2, m1, is, na) = nr (m1, m2, is, na)
+              ENDDO
            ENDDO
         ENDDO
      ENDDO
-  ENDDO
+  ENDIF
 
   ! symmetrize the quantities nr -> ns
-  DO na = 1, nat  
-     nt = ityp (na)  
-     IF ( is_hubbard(nt) ) THEN  
-        DO is = 1, nspin  
-           DO m1 = 1, 2 * Hubbard_l(nt) + 1  
-              DO m2 = 1, 2 * Hubbard_l(nt) + 1  
-                 DO isym = 1, nsym  
-                    nb = irt (isym, na)  
-                    DO m0 = 1, 2 * Hubbard_l(nt) + 1  
-                       DO m00 = 1, 2 * Hubbard_l(nt) + 1  
+  DO na = 1, nat
+     nt = ityp (na)
+     IF ( is_hubbard(nt) ) THEN
+        DO is = 1, nspin
+           DO m1 = 1, 2 * Hubbard_l(nt) + 1
+              DO m2 = 1, 2 * Hubbard_l(nt) + 1
+                 DO isym = 1, nsym
+                    nb = irt (isym, na)
+                    DO m0 = 1, 2 * Hubbard_l(nt) + 1
+                       DO m00 = 1, 2 * Hubbard_l(nt) + 1
                           IF (Hubbard_l(nt).EQ.0) THEN
                              ns(m1,m2,is,na) = ns(m1,m2,is,na) +  &
                                    nr(m0,m00,is,nb) / nsym
@@ -173,19 +180,19 @@ SUBROUTINE new_ns(ns)
   ENDDO
 
   ! Now we make the matrix ns(m1,m2) strictly hermitean
-  DO na = 1, nat  
-     nt = ityp (na)  
-     IF ( is_hubbard(nt) ) THEN  
-        DO is = 1, nspin  
-           DO m1 = 1, 2 * Hubbard_l(nt) + 1  
-              DO m2 = m1, 2 * Hubbard_l(nt) + 1  
-                 psum = ABS ( ns(m1,m2,is,na) - ns(m2,m1,is,na) )  
-                 IF (psum.GT.1.d-10) THEN  
-                    WRITE( stdout, * ) na, is, m1, m2  
-                    WRITE( stdout, * ) ns (m1, m2, is, na)  
-                    WRITE( stdout, * ) ns (m2, m1, is, na)  
-                    CALL errore ('new_ns', 'non hermitean matrix', 1)  
-                 ELSE  
+  DO na = 1, nat
+     nt = ityp (na)
+     IF ( is_hubbard(nt) ) THEN
+        DO is = 1, nspin
+           DO m1 = 1, 2 * Hubbard_l(nt) + 1
+              DO m2 = m1, 2 * Hubbard_l(nt) + 1
+                 psum = ABS ( ns(m1,m2,is,na) - ns(m2,m1,is,na) )
+                 IF (psum.GT.1.d-10) THEN
+                    WRITE( stdout, * ) na, is, m1, m2
+                    WRITE( stdout, * ) ns (m1, m2, is, na)
+                    WRITE( stdout, * ) ns (m2, m1, is, na)
+                    CALL errore ('new_ns', 'non hermitean matrix', 1)
+                 ELSE
                     ns(m1,m2,is,na) = 0.5d0 * (ns(m1,m2,is,na) + &
                                                ns(m2,m1,is,na) )
                     ns(m2,m1,is,na) = ns(m1,m2,is,na)
@@ -193,7 +200,7 @@ SUBROUTINE new_ns(ns)
               ENDDO
            ENDDO
         ENDDO
-     ENDIF 
+     ENDIF
   ENDDO
 
   DEALLOCATE ( nr )
@@ -228,7 +235,7 @@ SUBROUTINE new_ns(ns)
     CALL init_us_2 (npw,igk_k(1,ik),xk(1,ik),vkb)
     CALL calbec (npw, vkb, evc, becp)
     !
-    IF ( gamma_only ) THEN 
+    IF ( gamma_only ) THEN
        p%r(:,:) = 0.0_DP
     ELSE
        p%k(:,:) = (0.0_DP,0.0_DP)
@@ -274,13 +281,13 @@ SUBROUTINE new_ns(ns)
     RETURN
   END SUBROUTINE compute_pproj
   !
-END SUBROUTINE new_ns 
+END SUBROUTINE new_ns
 
 
 SUBROUTINE new_ns_nc(ns)
   !-----------------------------------------------------------------------
   !
-  ! Noncollinear version (A. Smogunov). 
+  ! Noncollinear version (A. Smogunov).
   !
   USE io_global,            ONLY : stdout
   USE kinds,                ONLY : DP
@@ -301,7 +308,7 @@ SUBROUTINE new_ns_nc(ns)
   USE mp_bands,             ONLY : intra_bgrp_comm
   USE mp_pools,             ONLY : inter_pool_comm
   USE mp,                   ONLY : mp_sum
-
+  USE mod_sirius
   IMPLICIT NONE
   !
   ! I/O variables
@@ -310,7 +317,7 @@ SUBROUTINE new_ns_nc(ns)
   INTEGER :: ik, ibnd, is, js, i, j, sigmay2, na, nb, nt, isym,  &
              m1, m2, m3, m4, is1, is2, is3, is4, m0, m00, ldim, npw
 
-  COMPLEX(DP) , ALLOCATABLE :: nr (:,:,:,:,:), nr1 (:,:,:,:,:), proj(:,:) 
+  COMPLEX(DP) , ALLOCATABLE :: nr (:,:,:,:,:), nr1 (:,:,:,:,:), proj(:,:)
 
   COMPLEX(DP) :: z, zdotc
 
@@ -320,94 +327,111 @@ SUBROUTINE new_ns_nc(ns)
   CALL start_clock('new_ns')
   ldim = 2 * Hubbard_lmax + 1
 
-  ALLOCATE( nr(ldim,ldim,npol,npol,nat), nr1(ldim,ldim,npol,npol,nat) )  
+  ALLOCATE( nr(ldim,ldim,npol,npol,nat), nr1(ldim,ldim,npol,npol,nat) )
   ALLOCATE( proj(nwfcU,nbnd) )
-
-  nr  (:,:,:,:,:) = 0.d0
-  nr1 (:,:,:,:,:) = 0.d0
-  ns  (:,:,:,:)   = 0.d0
-
-!--
-!    loop on k points
-!
-  DO ik = 1, nks
-
-     npw = ngk (ik)
-     IF (nks > 1) THEN
-        CALL get_buffer  (evc, nwordwfc, iunwfc, ik)
-        CALL get_buffer (wfcU, nwordwfcU, iunhub, ik)
-     END IF
-     !
-     ! make the projection - FIXME: use ZGEMM or calbec instead
-     !
-     DO ibnd = 1, nbnd
-       DO i = 1, nwfcU
-         proj(i, ibnd) = zdotc (npwx*npol, wfcU (1, i), 1, evc (1, ibnd), 1)
-       ENDDO
+  if (use_sirius) then
+     call sirius_calculate_hubbard_occupancies()
+     call sirius_get_hubbard_occupancies_nc(ns(1,1,1,1), ldim)
+     do na = 1, nat
+        nt = ityp (na)
+        if ( is_hubbard(nt) ) then
+           ldim = 2 * Hubbard_l(nt) + 1
+           do m1 = 1, 2 * Hubbard_l(nt) + 1
+              do m2 = 1, 2 * Hubbard_l(nt) + 1
+                 do is1 = 1, npol
+                    do is2 = 1, npol
+                       nr(m1,m2,is1,is2,na) = ns(m1,m2, 2 * is1 + is2 - 2, na)
+                    ENDDO
+                 ENDDO
+              ENDDO
+           ENDDO
+        ENDIF
      ENDDO
-     CALL mp_sum ( proj, intra_bgrp_comm )
+     ns  (:,:,:,:)   = 0.d0
+  else
+
+
+     nr  (:,:,:,:,:) = 0.d0
+     nr1 (:,:,:,:,:) = 0.d0
+     ns  (:,:,:,:)   = 0.d0
+
+     !--
+     !    loop on k points
      !
-     ! compute the occupation matrix
-     !
-     do na = 1, nat  
-        nt = ityp (na)  
-        if ( is_hubbard(nt) ) then  
-          ldim = 2 * Hubbard_l(nt) + 1
+     DO ik = 1, nks
 
-          do m1 = 1, 2 * Hubbard_l(nt) + 1
-            do m2 = 1, 2 * Hubbard_l(nt) + 1
-              do is1 = 1, npol
-                do is2 = 1, npol
-
-                  do ibnd = 1, nbnd
-                    nr(m1,m2,is1,is2,na) = nr(m1,m2,is1,is2,na) + &
-                            wg(ibnd,ik) * CONJG( proj(offsetU(na)+m1+ldim*(is1-1),ibnd) ) * &
-                                           proj(offsetU(na)+m2+ldim*(is2-1),ibnd)
-                  enddo
-
-                enddo
+        npw = ngk (ik)
+        IF (nks > 1) THEN
+           CALL get_buffer  (evc, nwordwfc, iunwfc, ik)
+           CALL get_buffer (wfcU, nwordwfcU, iunhub, ik)
+        END IF
+        !
+        ! make the projection - FIXME: use ZGEMM or calbec instead
+        !
+        DO ibnd = 1, nbnd
+           DO i = 1, nwfcU
+              proj(i, ibnd) = zdotc (npwx*npol, wfcU (1, i), 1, evc (1, ibnd), 1)
+           ENDDO
+        ENDDO
+        CALL mp_sum ( proj, intra_bgrp_comm )
+        !
+        ! compute the occupation matrix
+        !
+        do na = 1, nat
+           nt = ityp (na)
+           if ( is_hubbard(nt) ) then
+              ldim = 2 * Hubbard_l(nt) + 1
+              do m1 = 1, 2 * Hubbard_l(nt) + 1
+                 do m2 = 1, 2 * Hubbard_l(nt) + 1
+                    do is1 = 1, npol
+                       do is2 = 1, npol
+                          do ibnd = 1, nbnd
+                             nr(m1,m2,is1,is2,na) = nr(m1,m2,is1,is2,na) + &
+                                  wg(ibnd,ik) * CONJG( proj(offsetU(na)+m1+ldim*(is1-1),ibnd) ) * &
+                                  proj(offsetU(na)+m2+ldim*(is2-1),ibnd)
+                          enddo
+                       enddo
+                    enddo
+                 enddo
               enddo
-            enddo
-          enddo
-
-        endif
+           endif
+        enddo
      enddo
+     !---
 
-  enddo
-!---
-
-  CALL mp_sum( nr, inter_pool_comm )
+     CALL mp_sum( nr, inter_pool_comm )
+  endif
 
 !--  symmetrize: nr  -->  nr1
 !
-  do na = 1, nat  
-    nt = ityp (na)  
-    if ( is_hubbard(nt) ) then  
+  do na = 1, nat
+    nt = ityp (na)
+    if ( is_hubbard(nt) ) then
 
-      do m1 = 1, 2 * Hubbard_l(nt) + 1  
-        do m2 = 1, 2 * Hubbard_l(nt) + 1  
+      do m1 = 1, 2 * Hubbard_l(nt) + 1
+        do m2 = 1, 2 * Hubbard_l(nt) + 1
           do is1 = 1, npol
             do is2 = 1, npol
 
-loopisym:     do isym = 1, nsym  
-                nb = irt (isym, na)  
+loopisym:     do isym = 1, nsym
+                nb = irt (isym, na)
 
                 do m3 = 1, 2 * Hubbard_l(nt) + 1
                   do m4 = 1, 2 * Hubbard_l(nt) + 1
                     do is3 = 1, npol
                       do is4 = 1, npol
-  
+
                         if (Hubbard_l(nt).eq.0) then
                           if (t_rev(isym).eq.1) then
                             nr1(m1,m2,is1,is2,na) = nr1(m1,m2,is1,is2,na) +      &
                               CONJG( d_spin_ldau(is1,is3,isym) )*                &
                                      nr(m4,m3,is4,is3,nb)/nsym  *                &
-                                     d_spin_ldau(is2,is4,isym)  
+                                     d_spin_ldau(is2,is4,isym)
                           else
                             nr1(m1,m2,is1,is2,na) = nr1(m1,m2,is1,is2,na) +      &
                               CONJG( d_spin_ldau(is1,is3,isym) )*                &
                                      nr(m3,m4,is3,is4,nb)/nsym  *                &
-                                     d_spin_ldau(is2,is4,isym)  
+                                     d_spin_ldau(is2,is4,isym)
                           endif
                         elseif (Hubbard_l(nt).eq.1) then
                           if (t_rev(isym).eq.1) then
@@ -456,18 +480,18 @@ loopisym:     do isym = 1, nsym
                   enddo
                 enddo
 
-              enddo  loopisym 
+              enddo  loopisym
 
             enddo
           enddo
         enddo
-      enddo 
+      enddo
 
     endif
   enddo
 !--
 
-!-- Setup the output matrix ns with combined spin index 
+!-- Setup the output matrix ns with combined spin index
 !
   DO na = 1, nat
      nt = ityp (na)
@@ -488,29 +512,29 @@ loopisym:     do isym = 1, nsym
 
 !-- make the matrix ns strictly hermitean
 !
-  DO na = 1, nat  
-     nt = ityp (na)  
-     IF ( is_hubbard(nt) ) THEN  
-        DO is1 = 1, npol  
+  DO na = 1, nat
+     nt = ityp (na)
+     IF ( is_hubbard(nt) ) THEN
+        DO is1 = 1, npol
          do is2 = 1, npol
            i = npol*(is1-1) + is2
            j = is1 + npol*(is2-1)
-           DO m1 = 1, 2 * Hubbard_l(nt) + 1  
-              DO m2 = 1, 2 * Hubbard_l(nt) + 1  
-                 psum = ABS ( ns(m1,m2,i,na) - CONJG(ns(m2,m1,j,na)) )  
-                 IF (psum.GT.1.d-10) THEN  
-                    WRITE( stdout, * ) na, m1, m2, is1, is2  
-                    WRITE( stdout, * ) ns (m1, m2, i, na)  
-                    WRITE( stdout, * ) ns (m2, m1, j, na)  
-                    CALL errore ('new_ns', 'non hermitean matrix', 1)  
-                 ELSE  
+           DO m1 = 1, 2 * Hubbard_l(nt) + 1
+              DO m2 = 1, 2 * Hubbard_l(nt) + 1
+                 psum = ABS ( ns(m1,m2,i,na) - CONJG(ns(m2,m1,j,na)) )
+                 IF (psum.GT.1.d-10) THEN
+                    WRITE( stdout, * ) na, m1, m2, is1, is2
+                    WRITE( stdout, * ) ns (m1, m2, i, na)
+                    WRITE( stdout, * ) ns (m2, m1, j, na)
+                    CALL errore ('new_ns', 'non hermitean matrix', 1)
+                 ELSE
                     ns (m2, m1, j, na) = CONJG( ns(m1, m2, i, na))
                  ENDIF
               ENDDO
            ENDDO
          enddo
         ENDDO
-     ENDIF 
+     ENDIF
   ENDDO
 !--
   DEALLOCATE ( nr, nr1 )
@@ -519,4 +543,3 @@ loopisym:     do isym = 1, nsym
   RETURN
 
 END SUBROUTINE new_ns_nc
-

--- a/PW/src/potinit.f90
+++ b/PW/src/potinit.f90
@@ -137,11 +137,12 @@ SUBROUTINE potinit()
 
      ! ... in the lda+U case set the initial value of ns
      IF (lda_plus_u) THEN
-        !
         IF (noncolin) THEN
            CALL init_ns_nc()
+           if (use_sirius) call sirius_get_hubbard_occupancies_nc(rho%ns_nc(1,1,1,1), 2 *  Hubbard_lmax + 1)
         ELSE
            CALL init_ns()
+           if(use_sirius) call sirius_get_hubbard_occupancies(rho%ns(1,1,1,1), 2 *  Hubbard_lmax + 1)
         ENDIF
         !
      ENDIF
@@ -322,4 +323,3 @@ SUBROUTINE nc_magnetization_from_lsda ( nnr, nspin, rho )
   RETURN
   !
 END SUBROUTINE nc_magnetization_from_lsda
-

--- a/PW/src/run_pwscf.f90
+++ b/PW/src/run_pwscf.f90
@@ -183,6 +183,14 @@ SUBROUTINE run_pwscf ( exit_status )
      !
      ! ... force calculation
      !
+
+     if (use_sirius) then
+        call put_density_to_sirius
+        if (.not.use_sirius_density_matrix) then
+           call put_density_matrix_to_sirius
+        endif
+     ENDIF
+
      IF ( lforce ) CALL forces()
      !
      ! ... stress calculation

--- a/PW/src/stres_hub.f90
+++ b/PW/src/stres_hub.f90
@@ -24,6 +24,7 @@ SUBROUTINE stres_hub ( sigmah )
    USE symme,     ONLY : symmatrix
    USE io_files,  ONLY : prefix
    USE io_global, ONLY : stdout, ionode
+   USE mod_sirius
    !
    IMPLICIT NONE
    !
@@ -41,6 +42,15 @@ SUBROUTINE stres_hub ( sigmah )
                    " stress in full LDA+U scheme is not yet implemented",1)
 
    sigmah(:,:) = 0.d0
+
+!   if (use_sirius) then
+!      call sirius_get_stress_tensor(c_str("hubbard"), sigmah(1, 1))
+!      sigmah = -sigmah * 2 ! convert to Ry
+!      call symmatrix ( sigmah )
+!      CALL stop_clock( 'stres_hub' )
+!      !call symmatrix ( sigmaloc )
+!      return
+!   endif
 
    ldim = 2 * Hubbard_lmax + 1
    ALLOCATE (dns(ldim,ldim,nspin,nat))

--- a/PW/src/stress.f90
+++ b/PW/src/stress.f90
@@ -67,13 +67,7 @@ subroutine stress ( sigma )
      CALL infomsg('stres', 'stress with USPP and electric fields (Berry) not implemented')
      RETURN
   END IF
-  if (use_sirius) then
-    call put_density_to_sirius
-    if (.not.use_sirius_density_matrix) then
-      call put_density_matrix_to_sirius
-    endif
-    call sirius_calculate_stress_tensor(kset_id)
-  endif
+
   !
   call start_clock ('stress')
   !
@@ -274,4 +268,3 @@ subroutine stress ( sigma )
          &   5x,'dft-nl  stress (kbar)',3f10.2/2(26x,3f10.2/)/ &
          &   5x,'TS-vdW  stress (kbar)',3f10.2/2(26x,3f10.2/)/ )
 end subroutine stress
-

--- a/PW/src/sum_band.f90
+++ b/PW/src/sum_band.f90
@@ -103,6 +103,13 @@ SUBROUTINE sum_band()
        call invfft ('Rho', psic, dfftp)
        rho%of_r(:,is) = psic(:)
     enddo
+    IF (lda_plus_u) THEN
+       IF(noncolin) THEN
+          CALL new_ns_nc(rho%ns_nc)
+       ELSE
+          CALL new_ns(rho%ns)
+       ENDIF
+    ENDIF
     CALL stop_clock( 'sum_band' )
     return
   endif

--- a/PW/src/v_of_rho.f90
+++ b/PW/src/v_of_rho.f90
@@ -701,7 +701,7 @@ SUBROUTINE v_hubbard(ns, v_hub, eth)
   USE lsda_mod,             ONLY : nspin
   USE control_flags,        ONLY : iverbosity
   USE io_global,            ONLY : stdout
-
+  use mod_sirius
   IMPLICIT NONE
   !
   REAL(DP), INTENT(IN)  :: ns(2*Hubbard_lmax+1,2*Hubbard_lmax+1,nspin,nat) 
@@ -720,7 +720,6 @@ SUBROUTINE v_hubbard(ns, v_hub, eth)
   v_hub(:,:,:,:) = 0.d0
 
   if (lda_plus_u_kind.eq.0) then
-
     DO na = 1, nat
        nt = ityp (na)
        IF (Hubbard_U(nt).NE.0.d0 .OR. Hubbard_alpha(nt).NE.0.d0) THEN
@@ -867,9 +866,7 @@ SUBROUTINE v_hubbard(ns, v_hub, eth)
                 enddo
               ENDDO
             ENDDO
-
           ENDDO
-
        endif
     enddo
 
@@ -883,8 +880,13 @@ SUBROUTINE v_hubbard(ns, v_hub, eth)
       write(stdout,*) '-------'
     ENDIF
 !--
+  ENDIF
 
-  endif
+  if (use_sirius) then
+     call sirius_set_hubbard_occupancies(ns(1,1,1,1), 2 * hubbard_lmax + 1)
+     !call sirius_calculate_hubbard_potential()
+     call sirius_set_hubbard_potential(v_hub(1,1,1,1), 2 * hubbard_lmax + 1)
+  ENDIF
 
   DEALLOCATE (u_matrix)
   RETURN
@@ -904,7 +906,7 @@ SUBROUTINE v_hubbard_nc(ns, v_hub, eth)
   USE lsda_mod,             ONLY : nspin
   USE control_flags,        ONLY : iverbosity
   USE io_global,            ONLY : stdout
-
+  use mod_sirius
   IMPLICIT NONE
   !
   COMPLEX(DP) :: ns(2*Hubbard_lmax+1,2*Hubbard_lmax+1,nspin,nat) 
@@ -1062,6 +1064,12 @@ SUBROUTINE v_hubbard_nc(ns, v_hub, eth)
 !--
 
   DEALLOCATE (u_matrix)
+
+  if (use_sirius) then
+     call sirius_set_hubbard_occupancies_nc(v_hub(1,1,1,1), 2 * hubbard_lmax + 1)
+     call sirius_set_hubbard_potential_nc(v_hub(1,1,1,1), 2 * hubbard_lmax + 1)
+  ENDIF
+
   RETURN
 END SUBROUTINE v_hubbard_nc
 !-------------------------------------------


### PR DESCRIPTION
Anton,

enclosed is the necessary modification of the code in QE for the hubbard correction. So far SIRIUS contains all code for treating the SCF loop for LDA+U except hubbard forces and stresses that are directly calculated by QE. I need to find out why calculating the forces and stresses with sirius does not give the same answer but I do not think it is critical at the moment since sirius will be released with QE modified anyway.

I will make a pull request for SIRIUS as well. I tried to keep modifications as little as possible.

Best

Mathieu

