### PR TITLE
fix illegal read in sirius_get_band_occupancies|energies

### DIFF
--- a/PW/src/mod_sirius.f90
+++ b/PW/src/mod_sirius.f90
@@ -1422,7 +1422,7 @@ MODULE mod_sirius
     ENDIF
     ! convert to Ry
     DO ik = 1, nkstot
-      et(:, ik) = 2.d0 * band_e(:, global_kpoint_index(nkstot, ik))
+      et(:, ik) = 2.d0 * band_e(:, ik)
     ENDDO
     !
     DEALLOCATE(band_e)
@@ -1515,7 +1515,7 @@ MODULE mod_sirius
       maxocc = 1.d0
     ENDIF
     DO ik = 1, nkstot
-      wg(:, ik) = bnd_occ(:, global_kpoint_index(nkstot, ik)) / maxocc * wk(ik)
+      wg(:, ik) = bnd_occ(:, ik) / maxocc * wk(ik)
     ENDDO
     !
     DEALLOCATE(bnd_occ)


### PR DESCRIPTION
Fix for  Issue https://github.com/electronic-structure/q-e-sirius/issues/20. The use of `global_kpoint_index(nkstot, ik)` seems to have been inconsistent. Replace it by `ik`, not entirely sure this is correct though.