### PR TITLE
create H0 before going into the linear solver

### DIFF
--- a/HP/src/hp_main.f90
+++ b/HP/src/hp_main.f90
@@ -59,6 +59,7 @@ PROGRAM hp_main
   CALL setup_sirius()
   CALL put_potential_to_sirius()
   CALL sirius_generate_d_operator_matrix(gs_handler)
+  CALL sirius_create_H0(gs_handler)
 #endif
   !
   ! Initialization

--- a/LR_Modules/response_kernels.f90
+++ b/LR_Modules/response_kernels.f90
@@ -265,7 +265,7 @@ SUBROUTINE sternheimer_kernel(first_iter, time_reversed, npert, lrdvpsi, iudvpsi
          CALL sirius_linear_solver( gs_handler, vkq=MATMUL(TRANSPOSE(at), xk(:,ikq)),&
             &num_gvec_kq_loc=npwq, gvec_kq_loc=vg_kq(:,:), dpsi=dpsi(1, 1),&
             &psi=evq(:, :), eigvals=et(1, ikmk), dvpsi=dvpsi(1,1), ld=npwx, num_spin_comp=npol,&
-            &alpha_pv=alpha_pv)
+            &alpha_pv=alpha_pv, spin=current_spin)
          !
          DEALLOCATE(vg_kq)
 #else


### PR DESCRIPTION
@toxa81 @gsavva I'm sorry for force-pusing to ristretto branch and removing the last commit. It prevented spack compilation of `q-e-sirius@ristretto ^sirius@develop`.

We should wait before merging it in the main branch until we have at the linear response (https://github.com/electronic-structure/SIRIUS/pull/810) merged into sirius@develop before merging this PR.

