### PR TITLE
nlcglib and other changes

### DIFF
--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -14,7 +14,9 @@ RUN spack install $SPEC_GCC_CPU
 ## copy source files of the pull request into container
 COPY . /qe-src
 
-RUN spack --color always dev-build --source-path /qe-src q-e-sirius@develop-ristretto
+RUN spack spec -I q-e-sirius@develop-ristretto ^$SPEC_GCC_CPU
+
+RUN spack --color always dev-build --source-path /qe-src q-e-sirius@develop-ristretto ^$SPEC_GCC_CPU
 #
 ## we need a fixed name for the build directory
 ## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM electronicstructure/sirius
+FROM docker.io/electronicstructure/sirius
 
 RUN spack spec -I $SPEC_GCC_CPU
 

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -1,0 +1,22 @@
+FROM electronicstructure/sirius
+
+RUN spack spec -I $SPEC_GCC_CPU
+
+RUN spack install $SPEC_GCC_CPU
+
+
+## show the spack's spec
+#RUN spack spec -I $SPECDEV
+#
+#RUN spack env create --with-view /opt/sirius sirius-env
+#RUN spack -e sirius-env add $SPECDEV
+#
+## copy source files of the pull request into container
+#COPY . /sirius-src
+#
+## build SIRIUS
+#RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPECDEV
+#
+## we need a fixed name for the build directory
+## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
+#RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -15,7 +15,7 @@ ENV SPEC_QE="q-e-sirius@develop-ristretto ^fftw+openmp ^${SPEC_GCC_CPU}"
 
 RUN spack spec -I $SPEC_QE
 
-RUN spack install --only=dependencies $SPEC_QE &> /dev/null
+RUN spack install --only=dependencies --source-path /qe-src $SPEC_QE
 
 RUN spack --color always dev-build --source-path /qe-src $SPEC_QE
 #

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -15,6 +15,8 @@ ENV SPEC_QE="q-e-sirius@develop-ristretto ^fftw+openmp ^${SPEC_GCC_CPU}"
 
 RUN spack spec -I $SPEC_QE
 
+RUN spack install --only=dependencies $SPEC_QE &> /dev/null
+
 RUN spack --color always dev-build --source-path /qe-src $SPEC_QE
 #
 ## we need a fixed name for the build directory

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -2,22 +2,14 @@ FROM docker.io/electronicstructure/sirius
 
 RUN spack external find --all --scope system --not-buildable
 
-## show the spack's spec
-#RUN spack spec -I $SPECDEV
-#
-#RUN spack env create --with-view /opt/sirius sirius-env
-#RUN spack -e sirius-env add $SPECDEV
-#
-## copy source files of the pull request into container
+# copy source files of the pull request into container
 COPY . /qe-src
 
 ENV SPEC_QE="q-e-sirius@develop-ristretto ^fftw+openmp ^${SPEC_GCC_CPU}"
 
 RUN spack spec -I $SPEC_QE
 
-#RUN spack install --only=dependencies --source-path /qe-src $SPEC_QE
-
-RUN spack --color always dev-build --source-path /qe-src $SPEC_QE > /dev/null
+RUN spack --color always dev-build --quiet --source-path /qe-src $SPEC_QE
 
 ## we need a fixed name for the build directory
 ## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -12,10 +12,9 @@ RUN spack install $SPEC_GCC_CPU
 #RUN spack -e sirius-env add $SPECDEV
 #
 ## copy source files of the pull request into container
-#COPY . /sirius-src
-#
-## build SIRIUS
-#RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPECDEV
+COPY . /qe-src
+
+RUN spack --color always dev-build --source-path /qe-src q-e-sirius@develop-ristretto
 #
 ## we need a fixed name for the build directory
 ## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -1,9 +1,6 @@
 FROM docker.io/electronicstructure/sirius
 
-RUN spack spec -I $SPEC_GCC_CPU
-
-RUN spack install $SPEC_GCC_CPU
-
+RUN spack external find --all --scope system --not-buildable
 
 ## show the spack's spec
 #RUN spack spec -I $SPECDEV
@@ -14,9 +11,11 @@ RUN spack install $SPEC_GCC_CPU
 ## copy source files of the pull request into container
 COPY . /qe-src
 
-RUN spack spec -I q-e-sirius@develop-ristretto ^$SPEC_GCC_CPU
+ENV SPEC_QE="q-e-sirius@develop-ristretto ^intel-oneapi-mkl+cluster ^${SPEC_GCC_CPU}"
 
-RUN spack --color always dev-build --source-path /qe-src q-e-sirius@develop-ristretto ^$SPEC_GCC_CPU
+RUN spack spec -I $SPEC_QE
+
+RUN spack --color always dev-build --source-path /qe-src $SPEC_QE
 #
 ## we need a fixed name for the build directory
 ## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -15,10 +15,10 @@ ENV SPEC_QE="q-e-sirius@develop-ristretto ^fftw+openmp ^${SPEC_GCC_CPU}"
 
 RUN spack spec -I $SPEC_QE
 
-RUN spack install --only=dependencies --source-path /qe-src $SPEC_QE
+#RUN spack install --only=dependencies --source-path /qe-src $SPEC_QE
 
-RUN spack --color always dev-build --source-path /qe-src $SPEC_QE
-#
+RUN spack --color always dev-build --source-path /qe-src $SPEC_QE > /dev/null
+
 ## we need a fixed name for the build directory
 ## here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
 #RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build

--- a/.ci/build.Dockerfile
+++ b/.ci/build.Dockerfile
@@ -11,7 +11,7 @@ RUN spack external find --all --scope system --not-buildable
 ## copy source files of the pull request into container
 COPY . /qe-src
 
-ENV SPEC_QE="q-e-sirius@develop-ristretto ^intel-oneapi-mkl+cluster ^${SPEC_GCC_CPU}"
+ENV SPEC_QE="q-e-sirius@develop-ristretto ^fftw+openmp ^${SPEC_GCC_CPU}"
 
 RUN spack spec -I $SPEC_QE
 

--- a/.ci/cscs.yml
+++ b/.ci/cscs.yml
@@ -1,0 +1,15 @@
+include:
+  - remote: 'https://gitlab.com/cscs-ci/recipes/-/raw/master/templates/v2/.ci-ext.yml'
+
+stages:
+  - build
+  - test
+
+build image:
+  extends: .container-builder
+  stage: build
+  timeout: 2h
+  variables:
+    DOCKERFILE: .ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    DOCKER_BUILD_ARGS: '["BASE_IMAGEIMAGE}", "SPECDEV=$SPEC"]'

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,4 +8,4 @@ insert_final_newline = true
 [*.{f90,F90}]
 charset = utf-8
 indent_style = space
-indent_size = 8
+indent_size = 2

--- a/.fortls
+++ b/.fortls
@@ -1,0 +1,31 @@
+{
+    "source_dirs": [
+        "PP",
+        "HP",
+        "PW",
+        "atomic",
+        "Modules",
+        "PW/src",
+        "upflib",
+        "XClib",
+        "LAXlib",
+        "KS_Solvers",
+        "UtilXlib"
+    ],
+    "excl_suffixes": [
+        "_skip.f90"
+    ],
+    "pp_suffixes": [
+        ".f03",
+        ".F90",
+        ".f90"
+    ],
+    "pp_defs": {
+        "HAVE_PACKAGE": "",
+        "__MPI": "",
+        "__TRACE": "",
+        "__SIRIUS": ""
+    },
+    "lowercase_intrinsics": true,
+    "debug_log": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ tags
 EPW/src/tmp
 LAXlib/*.fh
 KS_Solvers/*.fh
+spack-build-*
+spack-build-env.txt
+spack-build-out.txt
+spack-configure-args.txt

--- a/Modules/command_line_options.f90
+++ b/Modules/command_line_options.f90
@@ -13,7 +13,7 @@ MODULE command_line_options
   USE mp,        ONLY : mp_bcast
   USE mp_world,  ONLY : root, world_comm
   USE io_global, ONLY : meta_ionode
-  USE input_parameters, ONLY : use_sirius_nlcg, use_sirius_scf, sirius_cfg
+  USE input_parameters, ONLY : use_qe_scf, use_sirius_nlcg, use_sirius_scf, sirius_cfg
   !
   IMPLICIT NONE
   !
@@ -143,8 +143,9 @@ CONTAINS
 #if defined(__SIRIUS)
            CASE ( '-sirius_nlcg' )
               use_sirius_nlcg = .true.
-           CASE ( '-sirius_scf' )
-              use_sirius_scf = .true.
+            CASE ( '-use_qe_scf' )
+              use_sirius_scf = .false.
+              use_qe_scf = .true.
            CASE ( '-sirius_cfg')
               IF (read_string) THEN
                  CALL my_getarg ( input_command_line, narg, sirius_cfg)

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -1091,8 +1091,8 @@ MODULE input_parameters
         REAL(DP)          :: nlcg_kappa
         REAL(DP)          :: nlcg_tol
         CHARACTER(len=80) :: nlcg_smearing
-        CHARACTER(len=80) :: nlcg_smearing_allowed(2)
-        DATA nlcg_smearing_allowed / 'FD', 'GS' /
+        CHARACTER(len=80) :: nlcg_smearing_allowed(5)
+        DATA nlcg_smearing_allowed / 'FD', 'GS', 'MP', 'COLD', 'GAUSS' /
         CHARACTER(len=80) :: nlcg_processing_unit = 'none'
         CHARACTER(len=80) :: nlcg_processing_unit_allowed(3)
         DATA nlcg_processing_unit_allowed / 'none', 'cpu', 'gpu' /

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -32,6 +32,7 @@ MODULE input_parameters
   USE parameters, ONLY : nsx, natx, sc_size, nsolx
   USE wannier_new,ONLY : wannier_data
   USE upf_params, ONLY : lqmax
+  USE iso_c_binding, ONLY : c_char
   !
   IMPLICIT NONE
   !
@@ -1084,21 +1085,26 @@ MODULE input_parameters
 !=----------------------------------------------------------------------------=!
 !  NLCG Namelist Input Parameters
 !=----------------------------------------------------------------------------=!
+        CHARACTER(len=80, kind=C_CHAR) :: nlcg_method = 'mvp2'
         INTEGER           :: nlcg_maxiter
         INTEGER           :: nlcg_restart
-        REAL(DP)          :: nlcg_tau
+        REAL(DP)          :: nlcg_bt_step_length
         REAL(DP)          :: nlcg_T
-        REAL(DP)          :: nlcg_kappa
-        REAL(DP)          :: nlcg_tol
-        CHARACTER(len=80) :: nlcg_smearing
+        REAL(DP)          :: nlcg_pseudo_precond
+        REAL(DP)          :: nlcg_conv_thr
+        CHARACTER(len=80, kind=C_CHAR) :: nlcg_smearing
         CHARACTER(len=80) :: nlcg_smearing_allowed(5)
         DATA nlcg_smearing_allowed / 'FD', 'GS', 'MP', 'COLD', 'GAUSS' /
-        CHARACTER(len=80) :: nlcg_processing_unit = 'none'
+        CHARACTER(len=80, kind=C_CHAR) :: nlcg_processing_unit = 'none'
         CHARACTER(len=80) :: nlcg_processing_unit_allowed(3)
         DATA nlcg_processing_unit_allowed / 'none', 'cpu', 'gpu' /
+        CHARACTER(len=80) :: nlcg_method_allowed(1)
+        DATA nlcg_method_allowed / 'mvp2' /
 
-        NAMELIST / nlcg / nlcg_maxiter, nlcg_restart, nlcg_tau, nlcg_T, nlcg_kappa, &
-          nlcg_tol, nlcg_smearing, nlcg_processing_unit
+        NAMELIST / direct_minimization / nlcg_method, nlcg_maxiter, nlcg_restart, nlcg_bt_step_length, nlcg_T, &
+          nlcg_pseudo_precond, nlcg_conv_thr, nlcg_smearing, nlcg_processing_unit
+
+!
 #endif
 !
 !=----------------------------------------------------------------------------=!

--- a/Modules/input_parameters.f90
+++ b/Modules/input_parameters.f90
@@ -1929,7 +1929,8 @@ MODULE input_parameters
       LOGICAL :: xmloutput = .false.
       !! if TRUE PW produce an xml output
 
-      LOGICAL  :: use_sirius_scf = .FALSE.
+      LOGICAL :: use_qe_scf = .FALSE.
+      LOGICAL  :: use_sirius_scf = .true.
       LOGICAL  :: use_sirius_nlcg = .FALSE.
       CHARACTER(len=256) :: sirius_cfg
 

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -495,6 +495,8 @@ MODULE read_namelists_module
          nlcg_smearing = 'MP'
        CASE('fermi-dirac', 'f-d', 'fd', 'Fermi-Dirac', 'F-D', 'FD')
          nlcg_smearing = 'FD'
+       CASE('marzari-vanderbilt', 'cold', 'm-v', 'mv')
+         nlcg_smearing = 'COLD'
        CASE DEFAULT
          nlcg_smearing = 'GAUSS'
        END SELECT

--- a/Modules/read_namelists.f90
+++ b/Modules/read_namelists.f90
@@ -13,12 +13,13 @@
 !----------------------------------------------------------------------------
 MODULE read_namelists_module
   !----------------------------------------------------------------------------
-  !! This module handles the reading of input namelists.  
+  !! This module handles the reading of input namelists.
   !! Written by Carlo Cavazzoni, with many additions.
   !  --------------------------------------------------
   !
   USE kinds,     ONLY : DP
   USE input_parameters
+  USE constants, ONLY : K_BOLTZMANN_RY
   !
   IMPLICIT NONE
   !
@@ -60,7 +61,7 @@ MODULE read_namelists_module
        CHARACTER(LEN=2) :: prog
        !! specify the calling program
        !
-       CHARACTER(LEN=20) ::    temp_string 
+       CHARACTER(LEN=20) ::    temp_string
        !
        !
        IF ( prog == 'PW' ) THEN
@@ -127,7 +128,7 @@ MODULE read_namelists_module
        lelfield = .FALSE.
        lorbm = .FALSE.
        nberrycyc  = 1
-       lecrpa   = .FALSE.   
+       lecrpa   = .FALSE.
        lfcp = .FALSE.
        tqmmm = .FALSE.
        trism = .FALSE.
@@ -471,25 +472,34 @@ MODULE read_namelists_module
      !
      !=----------------------------------------------------------------------=!
      !
-     !-----------------------------------------------------------------------
      SUBROUTINE nlcg_defaults( prog )
              !
              IMPLICIT NONE
              !
-             CHARACTER(LEN=2) :: prog ! .. specify the calling probram
-#if defined(__SIRIUS)
-             nlcg_maxiter = 300
-             nlcg_restart = 10
-             nlcg_tau = 0.1_DP
-             nlcg_T = 300.0_DP
-             nlcg_kappa = 0.3_DP
-             nlcg_tol = 1.0E-9_DP
-             nlcg_smearing = 'FD'
-             nlcg_processing_unit = 'none'
-#endif
-             RETURN
-     END SUBROUTINE
+       CHARACTER(LEN=2) :: prog ! .. specify the calling program
 
+       nlcg_method = 'mvp2'
+       nlcg_maxiter = 300
+       nlcg_restart = 10
+       nlcg_bt_step_length = 0.1_DP
+       nlcg_T = degauss / K_BOLTZMANN_RY
+       nlcg_pseudo_precond = 0.3_DP
+       nlcg_conv_thr = conv_thr
+       nlcg_processing_unit = 'none'
+
+       SELECT CASE( trim(smearing) )
+       CASE('gaussian', 'gauss', 'Gaussian', 'Gauss')
+         ! this is gaussian, but use gaussian spline for nlcg
+         nlcg_smearing = 'GAUSS'
+       CASE('mp', 'm-p', 'methfessel-paxton')
+         nlcg_smearing = 'MP'
+       CASE('fermi-dirac', 'f-d', 'fd', 'Fermi-Dirac', 'F-D', 'FD')
+         nlcg_smearing = 'FD'
+       CASE DEFAULT
+         nlcg_smearing = 'GAUSS'
+       END SELECT
+       RETURN
+     END SUBROUTINE nlcg_defaults
      !
      !
      !----------------------------------------------------------------------
@@ -576,14 +586,14 @@ MODULE read_namelists_module
        w_1              = 0.01_DP
        w_2              = 0.50_DP
        !
-       ! FIRE minimization defaults 
+       ! FIRE minimization defaults
        !
        fire_nmin = 5 ! minimum number of steps P > 0 before dt increas
        fire_f_inc = 1.1_DP ! factor for time step increase
-       fire_f_dec = 0.5_DP ! factor for time step decrease 
+       fire_f_dec = 0.5_DP ! factor for time step decrease
        fire_alpha_init = 0.20_DP ! initial value of mixing factor
        fire_falpha = 0.99_DP ! modification of the mixing factor
-       fire_dtmax = 10.0_DP ! factor for calculating dtmax 
+       fire_dtmax = 10.0_DP ! factor for calculating dtmax
        RETURN
        !
      END SUBROUTINE
@@ -1273,18 +1283,19 @@ MODULE read_namelists_module
        IMPLICIT NONE
        !
 #if defined(__SIRIUS)
+       CALL mp_bcast( nlcg_method,           ionode_id, intra_image_comm)
        CALL mp_bcast( nlcg_maxiter,          ionode_id, intra_image_comm )
        CALL mp_bcast( nlcg_restart,          ionode_id, intra_image_comm )
-       CALL mp_bcast( nlcg_tau,              ionode_id, intra_image_comm )
+       CALL mp_bcast( nlcg_bt_step_length,   ionode_id, intra_image_comm )
        CALL mp_bcast( nlcg_T,                ionode_id, intra_image_comm )
-       CALL mp_bcast( nlcg_kappa,            ionode_id, intra_image_comm )
-       CALL mp_bcast( nlcg_tol,              ionode_id, intra_image_comm )
+       CALL mp_bcast( nlcg_pseudo_precond,   ionode_id, intra_image_comm )
+       CALL mp_bcast( nlcg_conv_thr,         ionode_id, intra_image_comm )
        CALL mp_bcast( nlcg_smearing,         ionode_id, intra_image_comm )
        CALL mp_bcast( nlcg_processing_unit,  ionode_id, intra_image_comm )
 #endif
        RETURN
        !
-     END SUBROUTINE
+     END SUBROUTINE nlcg_bcast
      !
      !
      !-----------------------------------------------------------------------
@@ -1912,18 +1923,23 @@ MODULE read_namelists_module
      END SUBROUTINE
      !=----------------------------------------------------------------------=!
      !
-     !  Check input values for Namelist NLCG
+     !  Check input values for Namelist DIRECT_MINIMIZATION (nlcg)
      !
      !=----------------------------------------------------------------------=!
      !
      !-----------------------------------------------------------------------
      SUBROUTINE nlcg_checkin( prog )
        IMPLICIT NONE
-       CHARACTER(LEN=2)  :: prog   ! ... specify the calling program
-#if defined(__SIRIUS)
        LOGICAL :: allowed = .FALSE.
        CHARACTER(LEN=20) :: sub_name = ' nlcg_checkin '
+       CHARACTER(LEN=2)  :: prog   ! ... specify the calling program
        INTEGER           :: i
+       DO i = 1, SIZE(nlcg_method_allowed)
+         IF( TRIM(nlcg_method) == nlcg_method_allowed(i) ) allowed = .TRUE.
+       END DO
+       IF( .NOT. allowed ) &
+         CALL errore( sub_name, ' nlcg_method "'// &
+         & TRIM(nlcg_method)//'" not allowed ',1)
 
        DO i = 1, SIZE(nlcg_smearing_allowed)
          IF( TRIM(nlcg_smearing) == nlcg_smearing_allowed(i) ) allowed = .TRUE.
@@ -1941,19 +1957,18 @@ MODULE read_namelists_module
 
        IF ( nlcg_T < 0.0_DP ) &
          CALL errore(sub_name, 'nlcg_T out of range', 1)
-       IF ( nlcg_tau < 0.0_DP .or. nlcg_tau >= 1 ) &
-         CALL errore(sub_name, 'nlcg_tau out of range', 1)
-       IF ( nlcg_kappa < 0.0_DP ) &
+       IF ( nlcg_bt_step_length < 0.0_DP .or. nlcg_bt_step_length >= 1 ) &
+         CALL errore(sub_name, 'nlcg_bt_step_length out of range', 1)
+       IF ( nlcg_pseudo_precond < 0.0_DP ) &
          CALL errore(sub_name, 'nlcg_kappa out of range', 1)
-       IF ( nlcg_tol < 0.0_DP ) &
-         CALL errore(sub_name, 'nlcg_tol out of range', 1)
+       IF ( nlcg_conv_thr < 0.0_DP ) &
+         CALL errore(sub_name, 'nlcg_conv_thr out of range', 1)
        IF ( nlcg_maxiter < 0 ) &
          CALL errore(sub_name, 'nlcg_maxiter out of range', 1)
        IF ( nlcg_restart < 0 ) &
          CALL errore(sub_name, 'nlcg_restart out of range', 1)
-#endif
        RETURN
-     END SUBROUTINE
+     END SUBROUTINE nlcg_checkin
      !
      !
      !-----------------------------------------------------------------------
@@ -2472,9 +2487,9 @@ MODULE read_namelists_module
        ! ... declare variables
        !
        CHARACTER(LEN=*) :: prog_
-       !! specifies the calling program, allowed:  
-       !! prog = 'PW'     pwscf  
-       !! prog = 'CP'     cp  
+       !! specifies the calling program, allowed:
+       !! prog = 'PW'     pwscf
+       !! prog = 'CP'     cp
        !! prog = 'PW+iPi' pwscf + i-Pi
        !
        INTEGER, INTENT(IN), optional :: unit
@@ -2551,13 +2566,34 @@ MODULE read_namelists_module
        ! ... NLCG namelist
        !
 #if defined(__SIRIUS)
-       IF ( use_sirius_nlcg ) THEN
-         ios = 0
+       !
+       ! ... NLCG namelist
+       ! call nclg_defaults here (note that it depends on inputs in SYSTEM)
+       CALL nlcg_defaults( prog )
+       ios = 0
+       IF( ionode ) THEN
+         READ( unit_loc, direct_minimization, iostat = ios )
+       END IF
+       ! bcast ios, because check_namelist_valid does comm too
+       CALL mp_bcast(ios, ionode_id, intra_image_comm)
+       IF ( ios /= 0) THEN
+         ! READ failed, check if namelist did not exist or if parsing failed
+         CALL check_namelist_valid(ios, unit_loc, "direct_minimization")
+         ! reset input position
          IF( ionode ) THEN
-           READ( unit_loc, nlcg, iostat = ios )
-         END IF
-         CALL check_namelist_read(ios, unit_loc, "nlcg")
-         !
+           REWIND(unit_loc)
+           READ(unit_loc, electrons, iostat = ios)
+         ENDIF
+
+         use_sirius_nlcg=.false.
+       ELSE
+         ! found the DIRECT_MINIMIZATION namelist
+         IF (use_qe_scf) THEN
+           CALL errore('read_namelists', 'DIRECT_MINIMIZATION namelist present while -use_qe_scf specified.', 1)
+         ENDIF
+         CALL check_namelist_read(ios, unit_loc, "direct_minimization")
+         use_sirius_nlcg=.true.
+         use_sirius_scf=.true.
          CALL nlcg_bcast( )
          CALL nlcg_checkin( prog )
        END IF
@@ -2568,30 +2604,23 @@ MODULE read_namelists_module
        !
        ios = 0
        IF ( ionode ) THEN
-          IF ( ( TRIM( calculation ) /= 'nscf'  .AND. &
-                 TRIM( calculation ) /= 'bands' ) .OR. &
-               ( TRIM( prog_ ) == 'PW+iPi' ) ) THEN
+         IF ( ( TRIM( calculation ) /= 'nscf'  .AND. &
+                TRIM( calculation ) /= 'bands' ) .OR. &
+                 ( TRIM( prog_ ) == 'PW+iPi' ) ) THEN
              READ( unit_loc, ions, iostat = ios )
-          END IF
+         END IF
           !
           ! SCF might (optionally) have &ions :: ion_positions = 'from_file'
           !
           IF ( (ios /= 0) .AND. TRIM( calculation ) == 'scf' ) THEN
-             ! presumably, not found: rewind the file pointer to the location
-             ! of the previous present section, in this case electrons
-             REWIND( unit_loc )
-             IF ( use_sirius_nlcg ) THEN
-#if defined(__SIRIUS)
-               READ( unit_loc, nlcg, iostat = ios )
-#endif
-             ELSE
-               READ( unit_loc, electrons, iostat = ios )
-             END IF
+            ! presumably, not found: rewind the file pointer to the location
+            ! of the previous present section, in this case electrons
+            REWIND( unit_loc )
+            READ( unit_loc, electrons, iostat = ios )
           END IF
+        END IF
           !
-       END IF
-       !
-       CALL check_namelist_read(ios, unit_loc, "ions")
+        CALL check_namelist_read(ios, unit_loc, "ions")
        !
        CALL ions_bcast( )
        CALL ions_checkin( prog )
@@ -2720,4 +2749,75 @@ MODULE read_namelists_module
        !
      END SUBROUTINE check_namelist_read
      !
+     !
+     SUBROUTINE last_line(unit_loc, line)
+       USE io_global, ONLY : ionode, ionode_id
+       ! USE mp,        ONLY : mp_bcast
+       ! USE mp_images, ONLY : intra_image_comm
+
+       IMPLICIT NONE
+
+       INTEGER,INTENT(IN) :: unit_loc
+       INTEGER :: ios
+       CHARACTER(len=*),INTENT(OUT) :: line
+
+       IF ( ionode ) THEN
+         ! go back one line
+         BACKSPACE(unit_loc)
+         DO
+           READ(unit_loc, '(A512)', iostat=ios) line
+           IF (ios /= 0) THEN
+             exit
+           END IF
+         END DO
+         ! reset to begin of file
+         REWIND(unit_loc)
+       END IF
+
+     END SUBROUTINE last_line
+     !
+     ! same as check_namelist_read, but check only for validity, e.g. do not throw if namelist wasn't found
+     SUBROUTINE check_namelist_valid(ios, unit_loc, nl_name)
+       USE io_global, ONLY : ionode, ionode_id
+       USE mp,        ONLY : mp_bcast
+       USE mp_images, ONLY : intra_image_comm
+       !
+       IMPLICIT NONE
+       INTEGER,INTENT(in) :: ios, unit_loc
+       CHARACTER(LEN=*) :: nl_name
+       CHARACTER(len=512) :: line
+       CHARACTER(len=512) :: lastline
+       INTEGER :: ios2
+       !
+       IF( ionode ) THEN
+         ios2=0
+         IF (ios /=0) THEN
+           BACKSPACE(unit_loc)
+           READ(unit_loc,'(A512)', iostat=ios2) line
+         END IF
+
+         CALL last_line(unit_loc, lastline)
+       END IF
+
+       CALL mp_bcast( line, ionode_id, intra_image_comm )
+       CALL mp_bcast( lastline, ionode_id, intra_image_comm )
+
+       IF (lastline == line) THEN
+         ! 'lastline == line, this means nlcg namelist not found'
+         RETURN
+       END IF
+
+       CALL mp_bcast( ios2, ionode_id, intra_image_comm )
+       !
+       CALL mp_bcast( ios, ionode_id, intra_image_comm )
+       CALL mp_bcast( line, ionode_id, intra_image_comm )
+       IF( ios /= 0 ) THEN
+          CALL errore( ' read_namelists ', &
+                       ' bad line in namelist &'//TRIM(nl_name)//&
+                       ': "'//TRIM(line)//'" (error could be in the previous line)',&
+                       1 )
+       END IF
+       !
+     END SUBROUTINE check_namelist_valid
+
 END MODULE read_namelists_module

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -594,10 +594,11 @@ SUBROUTINE electrons_scf ( printout, exxen )
             WRITE(*,*)'============================='
 
             !CALL insert_xc_functional_to_sirius
-            CALL sirius_nlcg_params(gs_handler, ks_handler, nlcg_T, TRIM(ADJUSTL(nlcg_smearing))&
-                    &, nlcg_pseudo_precond, nlcg_bt_step_length, nlcg_conv_thr, nlcg_maxiter, nlcg_restart,&
-                    & TRIM(ADJUSTL(nlcg_processing_unit)))
-            conv_elec = .TRUE.
+            CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T, smearing&
+              &=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond, tau&
+              &=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
+              & restart=nlcg_restart, processing_unit&
+              &=TRIM(ADJUSTL(nlcg_processing_unit)), converged=conv_elec)
     END IF
 
     CALL stop_clock( 'electrons' )

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -590,17 +590,17 @@ SUBROUTINE electrons_scf ( printout, exxen )
     descf = descf * 2.d0 ! convert to Ry
 
     IF (use_sirius_nlcg) THEN
-            WRITE(*,*)''
-            WRITE(*,*)'============================='
-            WRITE(*,*)'* running NLCG ground state *'
-            WRITE(*,*)'============================='
+      WRITE(*,*)''
+      WRITE(*,*)'============================='
+      WRITE(*,*)'* running NLCG ground state *'
+      WRITE(*,*)'============================='
 
-            !CALL insert_xc_functional_to_sirius
-            CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T, smearing&
-              &=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond, tau&
-              &=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
-              & restart=nlcg_restart, processing_unit&
-              &=TRIM(ADJUSTL(nlcg_processing_unit)), converged=conv_elec)
+      !CALL insert_xc_functional_to_sirius
+      CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
+        &smearin=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,
+        &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
+        &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),
+        &converged=conv_elec)
     END IF
 
     CALL stop_clock( 'electrons' )
@@ -697,11 +697,11 @@ SUBROUTINE electrons_scf ( printout, exxen )
     WRITE(*,*)'* running NLCG ground state *'
     WRITE(*,*)'============================='
 
-    CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T, smearing&
-      &=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond, tau&
-      &=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
-      & restart=nlcg_restart, processing_unit&
-      &=TRIM(ADJUSTL(nlcg_processing_unit)), converged=conv_elec)
+    CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
+      &smearing=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond,
+      &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
+      &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),&
+      &converged=conv_elec)
   END IF
   !
   IF (use_sirius_scf.OR.use_sirius_nlcg) THEN

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -599,7 +599,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
       CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
         &smearin=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,&
         &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
-        &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),
+        &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),&
         &converged=conv_elec)
     END IF
 

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -597,7 +597,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
 
       !CALL insert_xc_functional_to_sirius
       CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
-        &smearin=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,
+        &smearin=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,&
         &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
         &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),
         &converged=conv_elec)
@@ -698,7 +698,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
     WRITE(*,*)'============================='
 
     CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
-      &smearing=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond,
+      &smearing=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond,&
       &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
       &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),&
       &converged=conv_elec)

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -582,7 +582,9 @@ SUBROUTINE electrons_scf ( printout, exxen )
     ! look only for the convergence of the density; converge total energy only to 10^-4
     CALL sirius_find_ground_state(gs_handler, density_tol=tr2, energy_tol=1d-4, max_niter=niter,&
         &iter_solver_tol=ethr, save_state=.false., converged=conv_elec, niter=iter)
-    CALL stop_clock( 'electrons' )
+    IF (conv_elec) THEN
+      n_scf_steps = iter
+    ENDIF
 
     CALL sirius_get_energy(gs_handler, "descf", descf)
     descf = descf * 2.d0 ! convert to Ry

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -684,6 +684,8 @@ SUBROUTINE electrons_scf ( printout, exxen )
 
     IF (conv_elec) THEN
       WRITE( stdout, 9110 ) iter
+    ELSE
+      WRITE( stdout, 9120 ) iter
     END IF
   END IF
   !

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -466,7 +466,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
   USE input_parameters,     ONLY : diago_thr_init
 #if defined(__SIRIUS)
   USE mod_sirius
-  USE input_parameters,     ONLY : nlcg_T, nlcg_tau, nlcg_tol, nlcg_kappa, nlcg_maxiter,&
+  USE input_parameters,     ONLY : nlcg_T, nlcg_bt_step_length, nlcg_conv_thr, nlcg_pseudo_precond, nlcg_maxiter,&
                                  & nlcg_restart, nlcg_smearing, nlcg_processing_unit
 #endif
   USE add_dmft_occ,         ONLY : dmft, dmft_update, v_dmft, dmft_updated
@@ -595,7 +595,7 @@ SUBROUTINE electrons_scf ( printout, exxen )
 
             !CALL insert_xc_functional_to_sirius
             CALL sirius_nlcg_params(gs_handler, ks_handler, nlcg_T, TRIM(ADJUSTL(nlcg_smearing))&
-                    &, nlcg_kappa, nlcg_tau, nlcg_tol, nlcg_maxiter, nlcg_restart,&
+                    &, nlcg_pseudo_precond, nlcg_bt_step_length, nlcg_conv_thr, nlcg_maxiter, nlcg_restart,&
                     & TRIM(ADJUSTL(nlcg_processing_unit)))
             conv_elec = .TRUE.
     END IF

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -597,9 +597,9 @@ SUBROUTINE electrons_scf ( printout, exxen )
 
       !CALL insert_xc_functional_to_sirius
       CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
-        &smearin=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,&
+        &smearing=TRIM(ADJUSTL(nlcg_smearing)), kappa=nlcg_pseudo_precond,&
         &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
-        &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),
+        &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),&
         &converged=conv_elec)
     END IF
 
@@ -689,19 +689,6 @@ SUBROUTINE electrons_scf ( printout, exxen )
     ELSE
       WRITE( stdout, 9120 ) iter
     END IF
-  END IF
-  !
-  IF (use_sirius_nlcg) THEN
-    WRITE(*,*)''
-    WRITE(*,*)'============================='
-    WRITE(*,*)'* running NLCG ground state *'
-    WRITE(*,*)'============================='
-
-    CALL sirius_nlcg_params(gs_handler, ks_handler, temp=nlcg_T,&
-      &smearing=TRIM(ADJUSTL(nlcg_smearing)) , kappa=nlcg_pseudo_precond,&
-      &tau=nlcg_bt_step_length, tol=nlcg_conv_thr, maxiter=nlcg_maxiter,&
-      &restart=nlcg_restart, processing_unit=TRIM(ADJUSTL(nlcg_processing_unit)),&
-      &converged=conv_elec)
   END IF
   !
   IF (use_sirius_scf.OR.use_sirius_nlcg) THEN

--- a/PW/src/forces.f90
+++ b/PW/src/forces.f90
@@ -140,7 +140,12 @@ SUBROUTINE forces()
     forcescc = 0.d0
     CALL sirius_get_forces(gs_handler, "usnl", forcenl)
     forcenl = forcenl * 2 ! convert to Ry
+
+    IF(.NOT.use_sirius_nlcg) THEN
+      ! scf correction term isn't present when using nlcg
     CALL sirius_get_forces(gs_handler, "scf_corr", forcescc)
+    ENDIF
+
     forcescc = forcescc * 2 ! convert to Ry
     IF ( use_veff_callback ) THEN
      CALL force_lc( nat, tau, ityp, alat, omega, ngm, ngl, igtongl, &

--- a/PW/src/forces.f90
+++ b/PW/src/forces.f90
@@ -143,21 +143,20 @@ SUBROUTINE forces()
 
     IF(.NOT.use_sirius_nlcg) THEN
       ! scf correction term isn't present when using nlcg
-    CALL sirius_get_forces(gs_handler, "scf_corr", forcescc)
+      CALL sirius_get_forces(gs_handler, "scf_corr", forcescc)
     ENDIF
 
     forcescc = forcescc * 2 ! convert to Ry
     IF ( use_veff_callback ) THEN
-     CALL force_lc( nat, tau, ityp, alat, omega, ngm, ngl, igtongl, &
-                 g, rho%of_r(:,1), gstart, gamma_only, vloc, &
-                 forcelc )
-     IF( do_comp_esm ) THEN
+      CALL force_lc( nat, tau, ityp, alat, omega, ngm, ngl, igtongl, &
+                 g, rho%of_r(:,1), gstart, gamma_only, vloc, forcelc )
+      IF( do_comp_esm ) THEN
         CALL esm_force_ew( forceion )
-     ELSE
+      ELSE
         CALL force_ew( alat, nat, ntyp, ityp, zv, at, bg, tau, omega, g, &
                        gg, ngm, gstart, gamma_only, gcutm, strf, forceion )
-     ENDIF
-     CALL force_cc( forcecc )
+      ENDIF
+      CALL force_cc( forcecc )
     ELSE
       CALL sirius_get_forces(gs_handler,"vloc", forcelc)
       forcelc = forcelc * 2 ! convert to Ry

--- a/PW/src/init_run.f90
+++ b/PW/src/init_run.f90
@@ -207,7 +207,9 @@ SUBROUTINE init_run()
   !
 #if defined(__MPI)
   ! Cleanup PAW arrays that are only used for init
-  IF (okpaw) CALL paw_post_init() ! only parallel!
+  IF (.NOT.(use_sirius_scf.OR.use_sirius_nlcg)) THEN
+    IF (okpaw) CALL paw_post_init()
+  ENDIF
 #endif
   !
   IF ( lmd ) CALL allocate_dyn_vars()

--- a/PW/src/mod_sirius.f90
+++ b/PW/src/mod_sirius.f90
@@ -909,6 +909,8 @@ MODULE mod_sirius
     SELECT CASE(ngauss)
       CASE (0)
         CALL sirius_set_parameters(sctx, smearing="gaussian")
+      CASE (1)
+        CALL sirius_set_parameters(sctx, smearing="methfessel_paxton")
       CASE(-1)
         CALL sirius_set_parameters(sctx, smearing="cold")
       CASE(-99)


### PR DESCRIPTION
- add new nlcg api
- add an optional `DIRECT_MINIZATION` namelist to input file (if present nlcglib is enabled)
- enable sirius automatically (as preferred by THEOS group), for vanilla QE  `-use_qe_scf` flag was added)
- don't call `post_init_PAW` which deallocates the PAW arrays, they are picked up later when calling `reset_gvectors` in https://github.com/electronic-structure/q-e-sirius/blob/nlcg-qe72/PW/src/run_pwscf.f90#L303, which calls `init_run` -> `setup_sirius`, where the PAW arrays are accessed again
- add a .fortls for fortran language server / set `.editorconfig` to use 2 spaces for indent 