### PR TITLE
[tweaks] introduce a few tweaks

### DIFF
--- a/PW/src/run_pwscf.f90
+++ b/PW/src/run_pwscf.f90
@@ -434,6 +434,7 @@ SUBROUTINE reset_gvectors( )
   USE fft_base,   ONLY : dfftp
   USE fft_base,   ONLY : dffts
   USE xc_lib,     ONLY : xclib_dft_is
+  USE mod_sirius
   ! 
   IMPLICIT NONE
   !
@@ -455,6 +456,14 @@ SUBROUTINE reset_gvectors( )
   dffts%nr1=0; dffts%nr2=0; dffts%nr3=0
   !
   CALL init_run()
+#if defined(__SIRIUS)
+  IF (use_sirius_scf.OR.use_sirius_nlcg.OR.always_setup_sirius) THEN
+    CALL clear_sirius
+    CALL setup_sirius
+    CALL sirius_initialize_kset(ks_handler)
+    !CALL sirius_initialize_subspace(gs_handler, ks_handler)
+  ENDIF
+#endif
   !
   ! ... re-set and re-initialize EXX-related stuff
   !

--- a/PW/src/stop_run.f90
+++ b/PW/src/stop_run.f90
@@ -57,11 +57,11 @@ SUBROUTINE stop_run( exit_status )
 #if defined(__SIRIUS)
   CALL sirius_finalize(call_mpi_fin=.false.)
   !WRITE(tname,'("timer",I4.4,".json")')mpime
-  IF (mpime.eq.0) THEN
-    CALL sirius_print_timers(.false.)
-    CALL sirius_print_timers(.true.)
-    CALL sirius_serialize_timers("timers.json")
-  ENDIF
+  !IF (mpime.eq.0) THEN
+  !  CALL sirius_print_timers(.false.)
+  !  CALL sirius_print_timers(.true.)
+  !  CALL sirius_serialize_timers("timers.json")
+  !ENDIF
   !CALL sirius_serialize_timers(string(trim(tname)))
 #endif
   !

--- a/PW/src/stop_run.f90
+++ b/PW/src/stop_run.f90
@@ -20,7 +20,6 @@ SUBROUTINE stop_run( exit_status )
   USE mp_global,          ONLY : mp_global_end
   USE environment,        ONLY : environment_end
   USE io_files,           ONLY : iuntmp, seqopn
-  USE mp_world, ONLY: mpime
   USE mod_sirius
   !
   IMPLICIT NONE
@@ -56,13 +55,6 @@ SUBROUTINE stop_run( exit_status )
   ! finalize sirius at the very end
 #if defined(__SIRIUS)
   CALL sirius_finalize(call_mpi_fin=.false.)
-  !WRITE(tname,'("timer",I4.4,".json")')mpime
-  !IF (mpime.eq.0) THEN
-  !  CALL sirius_print_timers(.false.)
-  !  CALL sirius_print_timers(.true.)
-  !  CALL sirius_serialize_timers("timers.json")
-  !ENDIF
-  !CALL sirius_serialize_timers(string(trim(tname)))
 #endif
   !
   CALL mp_global_end()


### PR DESCRIPTION
 * do not print timers by default; if you need timers, use SIRIUS_PRINT_TIMING env. variable
 * init sirius outside of init_run(); rationale: init_run is called in many places and in somce cases we don't need to initialise sirius, so be more explicit and do it only when needed

Fix: for vc-relax calculation reset_gvectors() must do a final initialisation of sirius

