### PR TITLE
Add vdw correction

### DIFF
--- a/.fortls
+++ b/.fortls
@@ -1,6 +1,7 @@
 {
     "source_dirs": [
         "PP",
+        "dft-d3",
         "HP",
         "PW",
         "atomic",

--- a/PW/src/electrons.f90
+++ b/PW/src/electrons.f90
@@ -577,6 +577,24 @@ SUBROUTINE electrons_scf ( printout, exxen )
         ewld = ewald( alat, nat, nsp, ityp, zv, at, bg, tau, &
                      omega, g, gg, ngm, gcutm, gstart, gamma_only, strf )
       END IF
+      !
+      ! Grimme-D3 correction to the energy
+      !
+      IF (ldftd3) THEN
+        CALL start_clock('energy_dftd3')
+        latvecs(:,:)=at(:,:)*alat
+        tau(:,:)=tau(:,:)*alat
+        DO na = 1, nat
+          atnum(na) = get_atomic_number(TRIM(atm(ityp(na))))
+        ENDDO
+        call dftd3_pbc_dispersion(dftd3,tau,atnum,latvecs,edftd3)
+        edftd3=edftd3*2.d0
+        tau(:,:)=tau(:,:)/alat
+        CALL stop_clock('energy_dftd3')
+      ELSE
+        edftd3= 0.0
+      ENDIF
+      !
     END IF
     CALL start_clock( 'electrons' )
     ! look only for the convergence of the density; converge total energy only to 10^-4

--- a/PW/src/forces.f90
+++ b/PW/src/forces.f90
@@ -169,8 +169,27 @@ SUBROUTINE forces()
       CALL sirius_get_forces(gs_handler,"hubbard", forceh)
       forceh = forceh * 2 ! convert to Ry
     ENDIF
+    !
+    ! ... The Grimme-D3 dispersion correction
+    !
+    IF ( ldftd3 ) THEN
+      !
+      CALL start_clock('force_dftd3')
+      ALLOCATE( force_d3(3, nat) )
+      force_d3(:,:) = 0.0_DP
+      latvecs(:,:) = at(:,:)*alat
+      tau(:,:) = tau(:,:)*alat
+      atnum(:) = get_atomic_number(atm(ityp(:)))
+      CALL dftd3_pbc_gdisp( dftd3, tau, atnum, latvecs, &
+        force_d3, stress_dftd3 )
+      force_d3 = -2.d0*force_d3
+      tau(:,:) = tau(:,:)/alat
+      CALL stop_clock('force_dftd3')
+    ENDIF
+    !
   ELSE
-#endif
+#endif ! __SIRIUS
+  ! IF NOT use_sirius_scf .AND. NOT use_sirius_nlcg
   !
   ! ... The nonlocal contribution is computed here
   !


### PR DESCRIPTION
As far as I understand (I might be wrong) Van der Waals correction set in `vdw_corr` is a "post-processing" only correction, ie it adds a an energy correction and term to the force, but doesn't add terms to the Hamiltonian.

Previously vdw_corr could be set, it was skipped in `electrons.f90` (SIRIUS returned before the relevant lines). It was partially skipped in `forces.f90`, but later `force_d3` was attempted to be added (which resulted in segfault).

This PR adds the relevant lines to `electrons.f90` to compute `edftd3` and to `force.f90`.

Alternatively we might want to throw an error if the user sets `vdw_cor!=none` in the input file.

Ref:
https://www.quantum-espresso.org/Doc/INPUT_PW.html#vdw_corr