### PR TITLE
Fixing a timer

### DIFF
--- a/HP/src/hp_print_clock.f90
+++ b/HP/src/hp_print_clock.f90
@@ -78,7 +78,7 @@ SUBROUTINE hp_print_clock
      CALL print_clock ('adddvscf')
      CALL print_clock ('addusdbec')
      CALL print_clock ('addusldos')
-     CALL print_clock ('hp_addusddens')
+     CALL print_clock ('lr_addusddens')
   ENDIF
   !
   RETURN


### PR DESCRIPTION
Timer for the time-consuming operation `lr_addusddens` is currently missing in QE.
Also, the existing timer printed, `hp_addusddens` does not exist.
Fixing this here