### PR TITLE
restructure calculation of newdq

### DIFF
--- a/LR_Modules/lr_addusddens.f90
+++ b/LR_Modules/lr_addusddens.f90
@@ -65,7 +65,7 @@ SUBROUTINE lr_addusddens (drhoscf, dbecsum)
 #if defined(__SIRIUS)
   DO nt = 1, ntyp
      IF (upf(nt)%tvanp) THEN
-        CALL sirius_generate_rhoaug_q(gs_handler, nt, nat, ngm, nspin_mag, atom_type(nt)%qpw1, &
+        CALL sirius_generate_rhoaug_q(gs_handler, nt, nat, ngm, nspin_mag, atom_type(nt)%qpw_t, &
             & nh(nt) * (nh(nt) + 1) / 2, eigqts, mill, dbecsum, nhm * (nhm + 1) / 2, aux)
      ENDIF
   ENDDO

--- a/LR_Modules/mod_lr_addons.f90
+++ b/LR_Modules/mod_lr_addons.f90
@@ -40,15 +40,15 @@ CONTAINS
 
     DO iat = 1, nsp
       IF (ALLOCATED(atom_type(iat)%qpw)) DEALLOCATE(atom_type(iat)%qpw)
-      IF (ALLOCATED(atom_type(iat)%qpw1)) DEALLOCATE(atom_type(iat)%qpw1)
+      IF (ALLOCATED(atom_type(iat)%qpw_t)) DEALLOCATE(atom_type(iat)%qpw_t)
       ALLOCATE(atom_type(iat)%qpw( ngm, nh(iat) * (1 + nh(iat)) / 2 ))
-      ALLOCATE(atom_type(iat)%qpw1( nh(iat) * (1 + nh(iat)) / 2, ngm))
+      ALLOCATE(atom_type(iat)%qpw_t( nh(iat) * (1 + nh(iat)) / 2, ngm))
       ijh = 0
       DO ih = 1, nh (iat)
         DO jh = ih, nh (iat)
           ijh = ijh + 1
           CALL qvan2 (ngm, ih, jh, iat, qmod, atom_type(iat)%qpw(:, ijh), ylmk0)
-          atom_type(iat)%qpw1(ijh, :) = atom_type(iat)%qpw(:, ijh)
+          atom_type(iat)%qpw_t(ijh, :) = atom_type(iat)%qpw(:, ijh)
         ENDDO
       ENDDO
     ENDDO

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -78,7 +78,7 @@ subroutine newdq (dvscf, npe)
         enddo
      enddo
 
-     do nt = 1, ntyp
+     do nt = 1, ntyp ! loop over atom types
         if (upf(nt)%tvanp ) then
           ijh = 0
            do ih = 1, nh (nt)
@@ -104,9 +104,9 @@ subroutine newdq (dvscf, npe)
                           int3(ih,jh,na,is,ipert) = omega * z1(is)
                        enddo
                     endif
-                 enddo
-              enddo
-           enddo
+                 enddo !na
+              enddo !jh
+           enddo !ih
            do na = 1, nat
               if (ityp(na) == nt) then
                  !
@@ -115,16 +115,17 @@ subroutine newdq (dvscf, npe)
                  do ih = 1, nh (nt)
                     do jh = ih, nh (nt)
                        do is = 1, nspin_mag
+                          !    lower triangle            upper triangle   
                           int3(jh,ih,na,is,ipert) = int3(ih,jh,na,is,ipert)
                        enddo
                     enddo
                  enddo
               endif
            enddo
-        endif
-     enddo
 
-  enddo
+        endif ! if US-PP
+     enddo ! nt
+  enddo ! ipert
 #if defined(__MPI)
   call mp_sum ( int3, intra_bgrp_comm )
 #endif

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -99,12 +99,14 @@ subroutine newdq (dvscf, npe)
                do na = 1, nat ! loop over all atoms
                   if (ityp(na) == nt) then
                      na_ = na_ + 1
+                     !$omp parallel do default(shared) private(ig)
                      do ig = 1, ngm ! loop over G-vectors
                          tmp(ig, na_) = aux2(ig, is) * CONJG( eigts1(mill(1,ig),na) * &
                                                               eigts2(mill(2,ig),na) * &
                                                               eigts3(mill(3,ig),na) * &
                                                               eigqts(na) )
                      enddo
+                     !$omp end parallel do
                   endif
                enddo
                !=============== compute Q*V for all atoms of type nt

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -49,9 +49,7 @@ subroutine newdq (dvscf, npe)
   ! countera
 
   complex(DP), allocatable :: aux2 (:,:), veff (:), tmp(:,:), res2(:,:)
-  complex(DP), allocatable :: int3_new(:,:,:,:,:)
   ! work space
-  complex(DP) z1(nspin_mag), z2
 
   if (.not.okvan) return
   !
@@ -60,8 +58,6 @@ subroutine newdq (dvscf, npe)
   int3 (:,:,:,:,:) = (0.d0, 0.0d0)
   allocate (aux2 (ngm , nspin_mag))
   allocate (veff (dfftp%nnr))
-  allocate (int3_new(nhm,nhm,nat,nspin_mag,npe))
-  int3_new (:,:,:,:,:) = (0.d0, 0.0d0)
   !
   !     and for each perturbation of this irreducible representation
   !     integrate the change of the self consistent potential and
@@ -130,9 +126,9 @@ subroutine newdq (dvscf, npe)
                      do ih = 1, nh(nt) ! loop over ksi
                         do jh = ih, nh(nt) ! loop over ksi'
                            ijh = ijh + 1
-                           int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
-                           !                     lower triangle                upper triangle   
-                           IF (jh > ih) int3_new(jh,ih,na,is,ipert) = int3_new(ih,jh,na,is,ipert)
+                           int3(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
+                           !                 lower triangle            upper triangle
+                           IF (jh > ih) int3(jh,ih,na,is,ipert) = int3(ih,jh,na,is,ipert)
                         enddo
                      enddo
                   endif
@@ -144,7 +140,6 @@ subroutine newdq (dvscf, npe)
         endif ! if US-PP
      enddo ! nt
   enddo ! ipert
-int3 = int3_new
 #if defined(__MPI)
   call mp_sum ( int3, intra_bgrp_comm )
 #endif

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -113,8 +113,10 @@ subroutine newdq (dvscf, npe)
                enddo
                !=============== compute Q*V for all atoms of type nt
                !    DGEMM( TA,  TB,    M,   N,   K, ALPHA,   A, LDA,                        B, LDB,  BETA,   C,  LDC)
-!              call ZGEMM('T', 'N', N_nt, nij, ngm, 1.0d0, tmp, ngm, CONJG(atom_type(nt)%qpw), ngm, 0.0d0, res1, N_nt)
-               call ZGEMM('C', 'N', nij, N_nt, ngm, 1.0d0, atom_type(nt)%qpw, ngm, tmp, ngm, 0.0d0, res2, nij)
+!              call ZGEMM('T', 'N', N_nt, nij, ngm, dcmplx(1.d0, 0.d0), tmp, ngm, &
+!                         CONJG(atom_type(nt)%qpw), ngm, dcmplx(0.d0, 0.d0), res1, N_nt)
+               call ZGEMM('C', 'N', nij, N_nt, ngm, dcmplx(1.d0, 0.d0), atom_type(nt)%qpw, &
+                          ngm, tmp, ngm, dcmplx(0.d0, 0.d0), res2, nij)
 
                ! tmp is a complex array of dimension (ngm, N_nt)
                ! qpw is a complex array of dimension (ngm, nij)

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -81,8 +81,6 @@ subroutine newdq (dvscf, npe)
 
      do nt = 1, ntyp ! loop over atom types
         if (upf(nt)%tvanp ) then
-           !======================================================================= my changes below
-           ijh = 0
            ! composite index for ih and jh (ksi and ksi')
            nij = nh(nt)*(nh(nt)+1)/2 ! max number of (ih,jh) pairs per atom type nt
            N_nt = 0 ! number of atoms of type nt
@@ -96,6 +94,7 @@ subroutine newdq (dvscf, npe)
            do is = 1, nspin_mag ! loop over spins
                na_ = 0 ! count atoms of type nt
                !=============== compute potential (aux2) * phase factors
+               call start_clock ('aux2_x_phases')
                do na = 1, nat ! loop over all atoms
                   if (ityp(na) == nt) then
                      na_ = na_ + 1
@@ -109,11 +108,14 @@ subroutine newdq (dvscf, npe)
                      !$omp end parallel do
                   endif
                enddo
+               call stop_clock ('aux2_x_phases')
                !=============== compute Q*V for all atoms of type nt
 !              call ZGEMM('T', 'N', N_nt, nij, ngm, dcmplx(1.d0, 0.d0), tmp, ngm, &
 !                         CONJG(atom_type(nt)%qpw), ngm, dcmplx(0.d0, 0.d0), res1, N_nt)
+               call start_clock ('newdq_ZGEMM')
                call ZGEMM('C', 'N', nij, N_nt, ngm, dcmplx(1.d0, 0.d0), atom_type(nt)%qpw, &
                           ngm, tmp, ngm, dcmplx(0.d0, 0.d0), res2, nij)
+               call stop_clock ('newdq_ZGEMM')
 
                ! tmp is a complex array of dimension (ngm, N_nt)
                ! qpw is a complex array of dimension (ngm, nij)

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -156,7 +156,7 @@ subroutine newdq (dvscf, npe)
                !=============== compute Q*V for all atoms of type nt
                !    DGEMM( TA,  TB,    M,   N,   K, ALPHA,   A, LDA,                        B, LDB,  BETA,   C,  LDC)
                call ZGEMM('T', 'N', N_nt, nij, ngm, 1.0d0, tmp, ngm, CONJG(atom_type(nt)%qpw), ngm, 0.0d0, res1, N_nt)
-               call ZGEMM('C', 'N', nij, N_nt, ngm, 1.0d0, atom_type(nt)%qpw, ngm, tmp, ngm, 0.0d0, res2, nij)
+!              call ZGEMM('C', 'N', nij, N_nt, ngm, 1.0d0, atom_type(nt)%qpw, ngm, tmp, ngm, 0.0d0, res2, nij)
 
                ! tmp is a complex array of dimension (ngm, N_nt)
                ! qpw is a complex array of dimension (ngm, nij)
@@ -171,8 +171,8 @@ subroutine newdq (dvscf, npe)
                      do ih = 1, nh(nt) ! loop over ksi
                         do jh = ih, nh(nt) ! loop over ksi'
                            ijh = ijh + 1
-!                          int3_new(ih,jh,na,is,ipert) = omega * res1(na_, ijh)
-                           int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
+                           int3_new(ih,jh,na,is,ipert) = omega * res1(na_, ijh)
+!                          int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
                            !                     lower triangle                upper triangle   
                            IF (jh > ih) int3_new(jh,ih,na,is,ipert) = int3_new(ih,jh,na,is,ipert)
                         enddo

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -106,17 +106,14 @@ subroutine newdq (dvscf, npe)
                enddo
                call stop_clock ('aux2_x_phases')
                !=============== compute Q*V for all atoms of type nt
-!              call ZGEMM('T', 'N', N_nt, nij, ngm, dcmplx(1.d0, 0.d0), tmp, ngm, &
-!                         CONJG(atom_type(nt)%qpw), ngm, dcmplx(0.d0, 0.d0), res1, N_nt)
                call start_clock ('newdq_ZGEMM')
+               ! qpw is a complex array of dimension (ngm, nij)
+               ! tmp is a complex array of dimension (ngm, N_nt)
+               ! --- (qpw)^H * tmp : (nij,  ngm) x (ngm, N_nt) = (nij, N_nt), dimensions of res2
+
                call ZGEMM('C', 'N', nij, N_nt, ngm, dcmplx(1.d0, 0.d0), atom_type(nt)%qpw, &
                           ngm, tmp, ngm, dcmplx(0.d0, 0.d0), res2, nij)
                call stop_clock ('newdq_ZGEMM')
-
-               ! tmp is a complex array of dimension (ngm, N_nt)
-               ! qpw is a complex array of dimension (ngm, nij)
-               ! --- (tmp)^T * qpw : (N_nt, ngm) x (ngm, nij)  = (N_nt, nij), dimensions of res1
-               ! --- (qpw)^H * tmp : (nij,  ngm) x (ngm, N_nt) = (nij, N_nt), dimensions of res2
 
                na_ = 0
                do na = 1, nat ! loop over all atoms

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -52,7 +52,6 @@ subroutine newdq (dvscf, npe)
   complex(DP), allocatable :: int3_new(:,:,:,:,:)
   ! work space
   complex(DP) z1(nspin_mag), z2
-  real(8) :: diff
 
   if (.not.okvan) return
   !
@@ -169,7 +168,6 @@ subroutine newdq (dvscf, npe)
                   if (ityp(na) == nt) then
                      na_ = na_ + 1
                      ijh = 0
-                     diff = 0
                      do ih = 1, nh(nt) ! loop over ksi
                         do jh = ih, nh(nt) ! loop over ksi'
                            ijh = ijh + 1
@@ -177,10 +175,8 @@ subroutine newdq (dvscf, npe)
                            int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
                            !                     lower triangle                upper triangle   
                            IF (jh > ih) int3_new(jh,ih,na,is,ipert) = int3_new(ih,jh,na,is,ipert)
-                           diff = diff + abs(int3_new(ih,jh,na,is,ipert) - int3(ih,jh,na,is,ipert))
                         enddo
                      enddo
-                     write(*,*)'na, diff = ',na, diff
                   endif
                enddo
            enddo ! loop over spins

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -82,48 +82,6 @@ subroutine newdq (dvscf, npe)
 
      do nt = 1, ntyp ! loop over atom types
         if (upf(nt)%tvanp ) then
-!           ijh = 0
-!            do ih = 1, nh (nt)
-!               do jh = ih, nh (nt)
-!                  ijh = ijh + 1
-!                  !call qvan2 (ngm, ih, jh, nt, qmod, qgm, ylmk0)
-!                  do na = 1, nat
-!                     if (ityp (na) == nt) then
-!                        z1 = (0.d0, 0.d0)
-! !$omp parallel do default(shared) private(z2, is) reduction(+:z1)
-!                        do ig = 1, ngm
-!                           z2 = atom_type(nt)%qpw(ig, ijh) * &
-!                                 eigts1(mill(1,ig),na) * &
-!                                 eigts2(mill(2,ig),na) * &
-!                                 eigts3(mill(3,ig),na) * &
-!                                 eigqts(na)
-!                           do is = 1, nspin_mag
-!                              z1(is) = z1(is) + conjg(z2) * aux2(ig, is)
-!                           enddo
-!                        enddo !ig
-! !$omp end parallel do
-!                        do is = 1, nspin_mag
-!                           int3(ih,jh,na,is,ipert) = omega * z1(is)
-!                        enddo
-!                     endif
-!                  enddo !na
-!               enddo !jh
-!            enddo !ih
-!            do na = 1, nat
-!               if (ityp(na) == nt) then
-!                  !
-!                  !    We use the symmetry properties of the ps factor
-!                  !
-!                  do ih = 1, nh (nt)
-!                     do jh = ih, nh (nt)
-!                        do is = 1, nspin_mag
-!                           !    lower triangle            upper triangle   
-!                           int3(jh,ih,na,is,ipert) = int3(ih,jh,na,is,ipert)
-!                        enddo
-!                     enddo
-!                  enddo
-!               endif
-!            enddo
            !======================================================================= my changes below
            ijh = 0
            ! composite index for ih and jh (ksi and ksi')

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -82,48 +82,48 @@ subroutine newdq (dvscf, npe)
 
      do nt = 1, ntyp ! loop over atom types
         if (upf(nt)%tvanp ) then
-          ijh = 0
-           do ih = 1, nh (nt)
-              do jh = ih, nh (nt)
-                 ijh = ijh + 1
-                 !call qvan2 (ngm, ih, jh, nt, qmod, qgm, ylmk0)
-                 do na = 1, nat
-                    if (ityp (na) == nt) then
-                       z1 = (0.d0, 0.d0)
-!$omp parallel do default(shared) private(z2, is) reduction(+:z1)
-                       do ig = 1, ngm
-                          z2 = atom_type(nt)%qpw(ig, ijh) * &
-                                eigts1(mill(1,ig),na) * &
-                                eigts2(mill(2,ig),na) * &
-                                eigts3(mill(3,ig),na) * &
-                                eigqts(na)
-                          do is = 1, nspin_mag
-                             z1(is) = z1(is) + conjg(z2) * aux2(ig, is)
-                          enddo
-                       enddo !ig
-!$omp end parallel do
-                       do is = 1, nspin_mag
-                          int3(ih,jh,na,is,ipert) = omega * z1(is)
-                       enddo
-                    endif
-                 enddo !na
-              enddo !jh
-           enddo !ih
-           do na = 1, nat
-              if (ityp(na) == nt) then
-                 !
-                 !    We use the symmetry properties of the ps factor
-                 !
-                 do ih = 1, nh (nt)
-                    do jh = ih, nh (nt)
-                       do is = 1, nspin_mag
-                          !    lower triangle            upper triangle   
-                          int3(jh,ih,na,is,ipert) = int3(ih,jh,na,is,ipert)
-                       enddo
-                    enddo
-                 enddo
-              endif
-           enddo
+!           ijh = 0
+!            do ih = 1, nh (nt)
+!               do jh = ih, nh (nt)
+!                  ijh = ijh + 1
+!                  !call qvan2 (ngm, ih, jh, nt, qmod, qgm, ylmk0)
+!                  do na = 1, nat
+!                     if (ityp (na) == nt) then
+!                        z1 = (0.d0, 0.d0)
+! !$omp parallel do default(shared) private(z2, is) reduction(+:z1)
+!                        do ig = 1, ngm
+!                           z2 = atom_type(nt)%qpw(ig, ijh) * &
+!                                 eigts1(mill(1,ig),na) * &
+!                                 eigts2(mill(2,ig),na) * &
+!                                 eigts3(mill(3,ig),na) * &
+!                                 eigqts(na)
+!                           do is = 1, nspin_mag
+!                              z1(is) = z1(is) + conjg(z2) * aux2(ig, is)
+!                           enddo
+!                        enddo !ig
+! !$omp end parallel do
+!                        do is = 1, nspin_mag
+!                           int3(ih,jh,na,is,ipert) = omega * z1(is)
+!                        enddo
+!                     endif
+!                  enddo !na
+!               enddo !jh
+!            enddo !ih
+!            do na = 1, nat
+!               if (ityp(na) == nt) then
+!                  !
+!                  !    We use the symmetry properties of the ps factor
+!                  !
+!                  do ih = 1, nh (nt)
+!                     do jh = ih, nh (nt)
+!                        do is = 1, nspin_mag
+!                           !    lower triangle            upper triangle   
+!                           int3(jh,ih,na,is,ipert) = int3(ih,jh,na,is,ipert)
+!                        enddo
+!                     enddo
+!                  enddo
+!               endif
+!            enddo
            !======================================================================= my changes below
            ijh = 0
            ! composite index for ih and jh (ksi and ksi')

--- a/LR_Modules/newdq.f90
+++ b/LR_Modules/newdq.f90
@@ -155,8 +155,8 @@ subroutine newdq (dvscf, npe)
                enddo
                !=============== compute Q*V for all atoms of type nt
                !    DGEMM( TA,  TB,    M,   N,   K, ALPHA,   A, LDA,                        B, LDB,  BETA,   C,  LDC)
-               call ZGEMM('T', 'N', N_nt, nij, ngm, 1.0d0, tmp, ngm, CONJG(atom_type(nt)%qpw), ngm, 0.0d0, res1, N_nt)
-!              call ZGEMM('C', 'N', nij, N_nt, ngm, 1.0d0, atom_type(nt)%qpw, ngm, tmp, ngm, 0.0d0, res2, nij)
+!              call ZGEMM('T', 'N', N_nt, nij, ngm, 1.0d0, tmp, ngm, CONJG(atom_type(nt)%qpw), ngm, 0.0d0, res1, N_nt)
+               call ZGEMM('C', 'N', nij, N_nt, ngm, 1.0d0, atom_type(nt)%qpw, ngm, tmp, ngm, 0.0d0, res2, nij)
 
                ! tmp is a complex array of dimension (ngm, N_nt)
                ! qpw is a complex array of dimension (ngm, nij)
@@ -171,8 +171,8 @@ subroutine newdq (dvscf, npe)
                      do ih = 1, nh(nt) ! loop over ksi
                         do jh = ih, nh(nt) ! loop over ksi'
                            ijh = ijh + 1
-                           int3_new(ih,jh,na,is,ipert) = omega * res1(na_, ijh)
-!                          int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
+!                          int3_new(ih,jh,na,is,ipert) = omega * res1(na_, ijh)
+                           int3_new(ih,jh,na,is,ipert) = omega * res2(ijh, na_)
                            !                     lower triangle                upper triangle   
                            IF (jh > ih) int3_new(jh,ih,na,is,ipert) = int3_new(ih,jh,na,is,ipert)
                         enddo

--- a/PW/src/mod_sirius.f90
+++ b/PW/src/mod_sirius.f90
@@ -46,7 +46,7 @@ MODULE mod_sirius
     !! lmax for beta-projectors
     !
     COMPLEX(8), ALLOCATABLE :: qpw(:, :)
-    COMPLEX(8), ALLOCATABLE :: qpw1(:, :)
+    COMPLEX(8), ALLOCATABLE :: qpw_t(:, :)
     !! plane-wave coefficients of Q-operator
     !
     INTEGER                 :: num_chi
@@ -1508,7 +1508,7 @@ MODULE mod_sirius
     IF (ALLOCATED(atom_type)) THEN
       DO iat = 1, nsp
         IF (ALLOCATED(atom_type(iat)%qpw)) DEALLOCATE(atom_type(iat)%qpw)
-        IF (ALLOCATED(atom_type(iat)%qpw1)) DEALLOCATE(atom_type(iat)%qpw1)
+        IF (ALLOCATED(atom_type(iat)%qpw_t)) DEALLOCATE(atom_type(iat)%qpw_t)
         IF (ALLOCATED(atom_type(iat)%l_chi)) DEALLOCATE(atom_type(iat)%l_chi)
         IF (ALLOCATED(atom_type(iat)%n_chi)) DEALLOCATE(atom_type(iat)%n_chi)
         IF (ALLOCATED(atom_type(iat)%chi)) DEALLOCATE(atom_type(iat)%chi)


### PR DESCRIPTION
use ZGEMM (instead if explicit loops) to calculate the contributions to D-matrix for all atoms of a given type in one-shot.

This means calling ZGEMM as many times as the atom *types*.
Two alternatives have been implemented [tmp = potential * CONJG(phases)]:
- res1 = (tmp)^T * CONJG(qpw)
- res2 = (qpw)^H * tmp

TODO:
- [x] test performance
