### PR TITLE
call cudaDeviceReset in sirius finalize

### DIFF
--- a/PW/src/stop_run.f90
+++ b/PW/src/stop_run.f90
@@ -54,7 +54,7 @@ SUBROUTINE stop_run( exit_status )
   CALL environment_end( 'PWSCF' )
   ! finalize sirius at the very end
 #if defined(__SIRIUS)
-  CALL sirius_finalize(call_mpi_fin=.false.)
+  CALL sirius_finalize(call_mpi_fin=.false., call_device_reset=.true.)
 #endif
   !
   CALL mp_global_end()


### PR DESCRIPTION
This seems to fix the crash in MPI_Finalize, not entirely clear why though. The sirius miniapp, did call cudaDeviceReset and didn't crash. 

```
GTL_DEBUG: [3] cudaHostUnregister: pointer does not correspond to a registered memory region
MPICH ERROR [Rank 3] [job id 19001.0] [Thu Jul  4 15:30:14 2024] [nid006079] - Abort(808544770) (rank 3 in comm 0): Fatal error in PMPI_Finalize: Invalid count, error stack:
PMPI_Finalize(214)...........................: MPI_Finalize failed
PMPI_Finalize(161)...........................: 
MPID_Finalize(713)...........................: 
MPIDI_SHMI_mpi_finalize_hook(87).............: 
MPIDI_POSIX_mpi_finalize_hook(151)...........: 
MPIDU_genq_shmem_pool_destroy_unsafe(327)....: 
MPIDU_genq_shmem_pool_gpu_mem_unregister(128): 
(unknown)(): Invalid count
```
