### PR TITLE
always use an MPI grid of 1xN

### DIFF
--- a/PW/src/mod_sirius.f90
+++ b/PW/src/mod_sirius.f90
@@ -1252,14 +1252,15 @@ MODULE mod_sirius
     END SELECT
     !
     num_ranks_k = nproc_image / npool
-    i = SQRT(DBLE(num_ranks_k) + 1d-10)
-    IF (i * i .NE. num_ranks_k) THEN
+    ! A square MPI grid for FFTs (2x2, 3x3, etc.) is slower than a 1xN MPI grid
+!   i = SQRT(DBLE(num_ranks_k) + 1d-10)
+!   IF (i * i .NE. num_ranks_k) THEN
       dims(1) = 1
       dims(2) = num_ranks_k
-    ELSE
-      dims(1) = i
-      dims(2) = i
-    ENDIF
+!   ELSE
+!     dims(1) = i
+!     dims(2) = i
+!   ENDIF
     CALL sirius_set_mpi_grid_dims(sctx, 2, dims(1))
     !
     !IF (diago_full_acc) THEN


### PR DESCRIPTION
Same as this older PR #71 but on top of `qe-7.4.1` instead.

Given a square number of ranks for PW parallelization, for example 4, 9, 16, the following code
```
    num_ranks_k = nproc_image / npool
    i = SQRT(DBLE(num_ranks_k) + 1d-10)
    IF (i * i .NE. num_ranks_k) THEN
      dims(1) = 1
      dims(2) = num_ranks_k
    ELSE
      dims(1) = i
      dims(2) = i
    ENDIF
```
creates an MPI grid of 2x2, 3x3, 4x4 respectively.
However, a square MPI grid, eg. 2x2, is slower than a 1x4 MPI grid